### PR TITLE
feat(backend): add exam service

### DIFF
--- a/backend/src/modules/exam/dto/create-exam.dto.ts
+++ b/backend/src/modules/exam/dto/create-exam.dto.ts
@@ -1,0 +1,43 @@
+import { IsString, IsInt, IsBoolean, IsOptional, IsEnum } from 'class-validator';
+
+export class CreateExamDto {
+  @IsString()
+  teacherId: string;
+
+  @IsString()
+  title: string;
+
+  @IsString()
+  subject: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsInt()
+  durationMinutes: number;
+
+  @IsOptional()
+  @IsBoolean()
+  shuffleQuestions?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  allowCopyPaste?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  requireFullscreen?: boolean;
+
+  @IsOptional()
+  @IsInt()
+  maxTabSwitches?: number;
+
+  @IsOptional()
+  @IsString()
+  startsAt?: string;
+
+  @IsOptional()
+  @IsString()
+  endsAt?: string;
+}

--- a/backend/src/modules/exam/dto/update-exam.dto.ts
+++ b/backend/src/modules/exam/dto/update-exam.dto.ts
@@ -1,0 +1,6 @@
+import { IsEnum } from 'class-validator';
+
+export class UpdateExamStatusDto {
+  @IsEnum(['draft', 'scheduled', 'published', 'closed'])
+  status: 'draft' | 'scheduled' | 'published' | 'closed';
+}

--- a/backend/src/modules/exam/exam.controller.ts
+++ b/backend/src/modules/exam/exam.controller.ts
@@ -1,0 +1,46 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body } from '@nestjs/common';
+import { ExamService } from './exam.service';
+import { CreateExamDto } from './dto/create-exam.dto';
+import { UpdateExamStatusDto } from './dto/update-exam.dto';
+
+
+@Controller('exams')
+export class ExamController {
+  constructor(private readonly examService: ExamService) {}
+
+  @Get()
+  getAllExams() {
+    return this.examService.getAllExams();
+  }
+
+  @Get(':id')
+  getExamById(@Param('id') id: string) {
+    return this.examService.getExamById(id);
+  }
+
+  @Get('teacher/:teacherId')
+  getExamsByTeacher(@Param('teacherId') teacherId: string) {
+    return this.examService.getExamsByTeacher(teacherId);
+  }
+
+  @Post()
+  createExam(@Body() body: CreateExamDto) {
+    return this.examService.createExam({
+      ...body,
+      id: crypto.randomUUID(),
+      status: 'draft',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  @Patch(':id/status')
+  updateExamStatus(@Param('id') id: string, @Body() body: UpdateExamStatusDto) {
+    return this.examService.updateExamStatus(id, body.status);
+  }
+
+  @Delete(':id')
+  deleteExam(@Param('id') id: string) {
+    return this.examService.deleteExam(id);
+  }
+}

--- a/backend/src/modules/exam/exam.module.ts
+++ b/backend/src/modules/exam/exam.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from 'src/database/database.module';
+import { ExamService } from './exam.service';
+import { ExamController } from './exam.controller';
+import { ExamResolver } from './exam.resolver';
+
+@Module({
+  imports: [DatabaseModule],
+  providers: [ExamService, ExamResolver],
+  controllers: [ExamController],
+})
+export class ExamModule {}

--- a/backend/src/modules/exam/exam.resolver.ts
+++ b/backend/src/modules/exam/exam.resolver.ts
@@ -1,0 +1,47 @@
+import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
+import { ExamService } from './exam.service';
+import { CreateExamDto } from './dto/create-exam.dto';
+
+@Resolver('Exam')
+export class ExamResolver {
+  constructor(private readonly examService: ExamService) {}
+
+  @Query(() => [Object])
+  getAllExams() {
+    return this.examService.getAllExams();
+  }
+
+  @Query(() => Object)
+  getExamById(@Args('id') id: string) {
+    return this.examService.getExamById(id);
+  }
+
+  @Query(() => [Object])
+  getExamsByTeacher(@Args('teacherId') teacherId: string) {
+    return this.examService.getExamsByTeacher(teacherId);
+  }
+
+  @Mutation(() => Object)
+  createExam(@Args('data') data: CreateExamDto) {
+    return this.examService.createExam({
+      ...data,
+      id: crypto.randomUUID(),
+      status: 'draft',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  @Mutation(() => Object)
+  updateExamStatus(
+    @Args('id') id: string,
+    @Args('status') status: string,
+  ) {
+    return this.examService.updateExamStatus(id, status as any);
+  }
+
+  @Mutation(() => Object)
+  deleteExam(@Args('id') id: string) {
+    return this.examService.deleteExam(id);
+  }
+}

--- a/backend/src/modules/exam/exam.service.ts
+++ b/backend/src/modules/exam/exam.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { NewExam, ExamStatus } from 'src/shared/types/exam.types';
+import { ExamRepository } from './exam.repository';
+
+@Injectable()
+export class ExamService {
+  constructor(private readonly examRepo: ExamRepository) {}
+
+  async getAllExams() {
+    return this.examRepo.findAllExams();
+  }
+
+  async getExamById(id: string) {
+    const exam = await this.examRepo.findExamById(id);
+    if (!exam) throw new NotFoundException('Exam not found');
+    return exam;
+  }
+
+  async getExamsByTeacher(teacherId: string) {
+    return this.examRepo.findExamsByTeacher(teacherId);
+  }
+
+  async createExam(data: NewExam) {
+    return this.examRepo.createExam(data);
+  }
+
+  async updateExamStatus(id: string, status: ExamStatus) {
+    await this.getExamById(id); // throws if not found
+    return this.examRepo.updateExamStatus(id, status);
+  }
+
+  async deleteExam(id: string) {
+    await this.getExamById(id); // throws if not found
+    return this.examRepo.deleteExam(id);
+  }
+}


### PR DESCRIPTION
## Summary

Added the exam service module with the initial service, resolver, and DTOs for exam-related operations.

## Problem

The backend did not yet have a dedicated exam module to organize exam business logic and API handling, which made it difficult to manage exam-related features in a structured way.

## Changes

* Added `exam.module`
* Added `exam.service`
* Added `exam.resolver`
* Added `create-exam.dto`
* Added `update-exam.dto`
* Set up the initial backend structure for exam-related functionality

## How to Test

Steps to verify the change:

1. Pull the branch and install dependencies
2. Run the backend application
3. Verify the exam module loads without errors
4. Check that the schema includes the exam resolver
5. Test exam-related queries or mutations if implemented

## Issue

Closes #39 