### PR TITLE
fix(cd): remove bun and update cd file

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
     paths:
-      - "backend/**"
-      - "frontend/**"
+      - "api/**"
+      - "web/**"
       - ".github/workflows/cd.yml"
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: backend
+        working-directory: api
 
     steps:
       - name: Checkout repository
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: 20
           cache: yarn
-          cache-dependency-path: backend/yarn.lock
+          cache-dependency-path: api/yarn.lock
 
       - name: Enable Corepack
         run: corepack enable
@@ -42,7 +42,7 @@ jobs:
         run: yarn build
 
       - name: Install Railway CLI
-        run: npm install -g @railway/cli
+        run: yarn global add @railway/cli
 
       - name: Validate Railway configuration
         run: |
@@ -65,7 +65,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: frontend
+        working-directory: web
 
     steps:
       - name: Checkout repository
@@ -75,20 +75,20 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: yarn
+          cache-dependency-path: web/yarn.lock
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.0.36
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install frontend dependencies
-        run: bun install --frozen-lockfile
+        run: yarn install --frozen-lockfile
 
       - name: Build frontend
-        run: bun run build
+        run: yarn build
 
       - name: Install Vercel CLI
-        run: npm install -g vercel
+        run: yarn global add vercel
 
       - name: Pull Vercel environment
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary

Fix CD workflow to match the monorepo folder structure and remove Bun dependency.

## Problem

CD pipeline referenced old folder names (`backend/`, `frontend/`) and used Bun and npm commands for installing CLI tools, inconsistent with the team's chosen package manager.

## Changes

* Updated `paths` triggers from `backend/**`, `frontend/**` to `api/**`, `web/**`
* Updated all `working-directory` references to `api/` and `web/`
* Updated `cache-dependency-path` to `api/yarn.lock` and `web/yarn.lock`
* Added `corepack enable` to both jobs
* Replaced `npm install -g @railway/cli` with `yarn global add @railway/cli`
* Replaced `npm install -g vercel` with `yarn global add vercel`
* Removed `Setup Bun` step from frontend deploy job
* Replaced all `bun` commands with `yarn`

## How to Test

1. Merge into `main`
2. Confirm both Railway and Vercel deploy jobs run successfully in Actions tab

## Issue

Closes #133