### PR TITLE
Fix/deploy setup

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
-yarn install
+set -e
+
+FOLDER=$1
+
+if [ -z "$FOLDER" ]; then
+  echo "Usage: ./scripts/deploy.sh [api|web]"
+  exit 1
+fi
+
+if [ "$FOLDER" != "api" ] && [ "$FOLDER" != "web" ]; then
+  echo "Error: folder must be 'api' or 'web'"
+  exit 1
+fi
+
+echo "Building $FOLDER..."
+cd "$FOLDER"
+yarn install --frozen-lockfile
 yarn build
-echo "Deploying app..."
+echo "$FOLDER build complete."


### PR DESCRIPTION
## Summary

Update deploy and test scripts to support monorepo folder structure.

## Problem

`deploy.sh` and `test.sh` had no awareness of the monorepo structure — they ran `yarn install` and `yarn build` from the root with no target folder, which would fail in a `web/` + `api/` setup.

## Changes

* `deploy.sh` now accepts `api` or `web` as an argument and runs from the correct folder
* `test.sh` now accepts `api` or `web` as an argument and runs from the correct folder
* Both scripts exit with a clear error message if no argument or an invalid argument is passed
* Added `set -e` to both scripts so they fail fast on any error

## How to Test

```bash
./scripts/deploy.sh api
./scripts/deploy.sh web
./scripts/test.sh api
```

## Issue

Closes #132 