### PR TITLE
feat(api): add answer session guards

### DIFF
--- a/api/src/modules/answer/answer.controller.ts
+++ b/api/src/modules/answer/answer.controller.ts
@@ -1,23 +1,49 @@
-import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { AnswerService } from './answer.service';
 import { UpsertAnswerDto } from './dto/upsert-answer.dto';
+import { ClerkAuthGuard } from 'src/modules/auth/guards/clerk-auth.guard';
+import { RolesGuard } from 'src/modules/auth/guards/roles.guard';
+import { Roles } from 'src/modules/auth/decorators/roles.decorator';
+import { CurrentUser } from 'src/modules/auth/decorators/current-user.decorator';
+import type { AuthenticatedUser } from 'src/modules/auth/interfaces/authenticated-user.interface';
 
 @Controller('answers')
+@UseGuards(ClerkAuthGuard, RolesGuard)
 export class AnswerController {
   constructor(private readonly answerService: AnswerService) {}
 
   @Get('session/:sessionId')
-  getAnswersBySession(@Param('sessionId') sessionId: string) {
-    return this.answerService.getAnswersBySession(sessionId);
+  @Roles('teacher', 'student')
+  getAnswersBySession(
+    @Param('sessionId') sessionId: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.answerService.getAnswersBySession(sessionId, user);
   }
 
   @Post('autosave')
-  autosaveAnswer(@Body() body: UpsertAnswerDto) {
-    return this.answerService.autosaveAnswer(body);
+  @Roles('student')
+  autosaveAnswer(
+    @Body() body: UpsertAnswerDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.answerService.autosaveAnswer(body, user);
   }
 
   @Patch('session/:sessionId/finalize')
-  finalizeAnswers(@Param('sessionId') sessionId: string) {
-    return this.answerService.finalizeAnswers(sessionId);
+  @Roles('student')
+  finalizeAnswers(
+    @Param('sessionId') sessionId: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.answerService.finalizeAnswers(sessionId, user);
   }
 }

--- a/api/src/modules/answer/answer.service.ts
+++ b/api/src/modules/answer/answer.service.ts
@@ -1,17 +1,27 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { AnswerRepository } from './answer.repository';
 import { SessionRepository } from '../session/session.repository';
 import type { NewAnswer } from 'src/shared/types';
+import type { AuthenticatedUser } from 'src/modules/auth/interfaces/authenticated-user.interface';
+import { QuestionRepository } from '../question/question.repository';
+import { ExamRepository } from '../exam/exam.repository';
 
 @Injectable()
 export class AnswerService {
   constructor(
     private readonly answerRepo: AnswerRepository,
     private readonly sessionRepo: SessionRepository,
+    private readonly questionRepo: QuestionRepository,
+    private readonly examRepo: ExamRepository,
   ) {}
 
-  async getAnswersBySession(sessionId: string) {
-    await this.ensureSessionExists(sessionId);
+  async getAnswersBySession(sessionId: string, user: AuthenticatedUser) {
+    await this.ensureSessionAccess(sessionId, user);
     return this.answerRepo.findAnswersBySession(sessionId);
   }
 
@@ -21,8 +31,17 @@ export class AnswerService {
     textAnswer?: string;
     formulaAnswerJson?: string;
     fileUrl?: string;
-  }) {
-    await this.ensureSessionExists(data.sessionId);
+  }, user: AuthenticatedUser) {
+    const session = await this.ensureSessionAccess(data.sessionId, user, true);
+    const question = await this.questionRepo.findQuestionById(data.questionId);
+
+    if (!question) {
+      throw new NotFoundException('Question not found');
+    }
+
+    if (question.examId !== session.examId) {
+      throw new BadRequestException('Question does not belong to this session exam');
+    }
 
     const now = new Date().toISOString();
     const payload: NewAnswer = {
@@ -40,16 +59,48 @@ export class AnswerService {
     return this.answerRepo.upsertAnswer(payload);
   }
 
-  async finalizeAnswers(sessionId: string) {
-    await this.ensureSessionExists(sessionId);
+  async finalizeAnswers(sessionId: string, user: AuthenticatedUser) {
+    await this.ensureSessionAccess(sessionId, user, true);
     return this.answerRepo.finalizeAnswers(sessionId);
   }
 
-  private async ensureSessionExists(sessionId: string) {
+  private async ensureSessionAccess(
+    sessionId: string,
+    user: AuthenticatedUser,
+    requireWritable = false,
+  ) {
     const session = await this.sessionRepo.findSessionById(sessionId);
 
     if (!session) {
       throw new NotFoundException('Session not found');
+    }
+
+    if (user.role === 'teacher') {
+      const exam = await this.examRepo.findExamById(session.examId);
+
+      if (!exam || exam.teacherId !== user.id) {
+        throw new ForbiddenException('You cannot access answers for this session');
+      }
+
+      if (requireWritable) {
+        throw new ForbiddenException('Teachers cannot modify student answers');
+      }
+
+      return session;
+    }
+
+    if (session.studentId !== user.id) {
+      throw new ForbiddenException('You cannot access this session');
+    }
+
+    if (requireWritable) {
+      if (session.status !== 'in_progress') {
+        throw new BadRequestException('Answers can only be changed during an active session');
+      }
+
+      if (session.submittedAt) {
+        throw new BadRequestException('Submitted sessions cannot be changed');
+      }
     }
 
     return session;


### PR DESCRIPTION
## Summary

Added answer and session guards to protect related API operations and enforce access control.

## Problem

The API did not have dedicated guards for answer and session flows, which made it harder to enforce validation and access rules consistently.

## Changes

* Added answer guards
* Added session guards
* Integrated the guards into the related API flow
* Improved protection for answer- and session-related operations

## How to Test

Steps to verify the change:

1. Pull the branch and install dependencies
2. Run the backend application
3. Access answer- and session-related endpoints or resolvers
4. Verify allowed requests pass successfully
5. Verify invalid or unauthorized requests are blocked as expected

## Issue

Closes #103 