### PR TITLE
feat(api): add monitoring access control

### DIFF
--- a/api/src/modules/monitoring/monitoring.controller.ts
+++ b/api/src/modules/monitoring/monitoring.controller.ts
@@ -1,33 +1,60 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { MonitoringService } from './monitoring.service';
 import { CreateEventDto } from './dto/create-event.dto';
+import { ClerkAuthGuard } from 'src/modules/auth/guards/clerk-auth.guard';
+import { RolesGuard } from 'src/modules/auth/guards/roles.guard';
+import { Roles } from 'src/modules/auth/decorators/roles.decorator';
+import { CurrentUser } from 'src/modules/auth/decorators/current-user.decorator';
+import type { AuthenticatedUser } from 'src/modules/auth/interfaces/authenticated-user.interface';
 
 @Controller('monitoring')
+@UseGuards(ClerkAuthGuard, RolesGuard)
 export class MonitoringController {
   constructor(private readonly monitoringService: MonitoringService) {}
 
   @Post('events')
-  logEvent(@Body() body: CreateEventDto) {
-    return this.monitoringService.logEvent(body);
+  @Roles('student')
+  logEvent(@Body() body: CreateEventDto, @CurrentUser() user: AuthenticatedUser) {
+    return this.monitoringService.logEvent(body, user);
   }
 
   @Get('events/exam/:examId')
-  getEventsByExam(@Param('examId') examId: string) {
-    return this.monitoringService.getEventsByExam(examId);
+  @Roles('teacher')
+  getEventsByExam(
+    @Param('examId') examId: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.monitoringService.getEventsByExam(examId, user);
   }
 
   @Get('events/session/:sessionId')
-  getEventsBySession(@Param('sessionId') sessionId: string) {
-    return this.monitoringService.getEventsBySession(sessionId);
+  @Roles('teacher')
+  getEventsBySession(
+    @Param('sessionId') sessionId: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.monitoringService.getEventsBySession(sessionId, user);
   }
 
   @Get('events/exam/:examId/live')
-  getLiveFeed(@Param('examId') examId: string) {
-    return this.monitoringService.getLiveFeed(examId);
+  @Roles('teacher')
+  getLiveFeed(
+    @Param('examId') examId: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.monitoringService.getLiveFeed(examId, user);
   }
 
   @Get('dashboard')
-  getDashboardStats() {
-    return this.monitoringService.getDashboardStats();
+  @Roles('teacher')
+  getDashboardStats(@CurrentUser() user: AuthenticatedUser) {
+    return this.monitoringService.getDashboardStats(user);
   }
 }

--- a/api/src/modules/monitoring/monitoring.service.ts
+++ b/api/src/modules/monitoring/monitoring.service.ts
@@ -1,9 +1,15 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { MonitoringRepository } from './monitoring.repository';
 import { SessionRepository } from '../session/session.repository';
 import { ExamRepository } from '../exam/exam.repository';
 import { NotificationService } from '../notification/notification.service';
 import type { NewMonitoringEvent } from 'src/shared/types';
+import type { AuthenticatedUser } from 'src/modules/auth/interfaces/authenticated-user.interface';
 
 @Injectable()
 export class MonitoringService {
@@ -20,19 +26,27 @@ export class MonitoringService {
     examId: string;
     eventType: NewMonitoringEvent['eventType'];
     metadataJson?: string;
-  }) {
+  }, user: AuthenticatedUser) {
     const session = await this.sessionRepo.findSessionById(data.sessionId);
 
     if (!session) {
       throw new NotFoundException('Session not found');
     }
 
+    if (session.studentId !== user.id) {
+      throw new ForbiddenException('You cannot log monitoring events for this session');
+    }
+
+    if (session.status !== 'in_progress') {
+      throw new BadRequestException('Monitoring events can only be logged for active sessions');
+    }
+
     const now = new Date().toISOString();
     const event = await this.monitoringRepo.createEvent({
       id: crypto.randomUUID(),
       sessionId: data.sessionId,
-      studentId: data.studentId,
-      examId: data.examId,
+      studentId: session.studentId,
+      examId: session.examId,
       eventType: data.eventType,
       metadataJson: data.metadataJson ?? null,
       occurredAt: now,
@@ -44,26 +58,65 @@ export class MonitoringService {
     return event;
   }
 
-  async getEventsByExam(examId: string) {
+  async getEventsByExam(examId: string, user?: AuthenticatedUser) {
+    if (user) {
+      await this.ensureTeacherOwnsExam(examId, user.id);
+    }
+
     return this.monitoringRepo.findEventsByExam(examId);
   }
 
-  async getEventsBySession(sessionId: string) {
+  async getEventsBySession(sessionId: string, user?: AuthenticatedUser) {
+    const session = await this.sessionRepo.findSessionById(sessionId);
+
+    if (!session) {
+      throw new NotFoundException('Session not found');
+    }
+
+    if (user) {
+      await this.ensureTeacherOwnsExam(session.examId, user.id);
+    }
+
     return this.monitoringRepo.findEventsBySession(sessionId);
   }
 
-  async getDashboardStats(limit = 20) {
+  async getDashboardStats(userOrLimit?: AuthenticatedUser | number, limit = 20) {
     const recentEvents = await this.monitoringRepo.findRecentEvents(limit);
-    const uniqueStudents = new Set(recentEvents.map((event) => event.studentId));
+    const user =
+      typeof userOrLimit === 'number' || !userOrLimit ? undefined : userOrLimit;
+    const requestedLimit =
+      typeof userOrLimit === 'number' ? userOrLimit : limit;
+
+    const scopedRecentEvents =
+      requestedLimit === limit
+        ? recentEvents
+        : await this.monitoringRepo.findRecentEvents(requestedLimit);
+
+    let teacherEvents = scopedRecentEvents;
+
+    if (user) {
+      const exams = await this.examRepo.findExamsByTeacher(user.id);
+      const teacherExamIds = new Set(exams.map((exam) => exam.id));
+
+      teacherEvents = scopedRecentEvents.filter((event) =>
+        teacherExamIds.has(event.examId),
+      );
+    }
+
+    const uniqueStudents = new Set(teacherEvents.map((event) => event.studentId));
 
     return {
-      totalEvents: recentEvents.length,
+      totalEvents: teacherEvents.length,
       uniqueStudents: uniqueStudents.size,
-      recentEvents,
+      recentEvents: teacherEvents,
     };
   }
 
-  async getLiveFeed(examId: string) {
+  async getLiveFeed(examId: string, user?: AuthenticatedUser) {
+    if (user) {
+      await this.ensureTeacherOwnsExam(examId, user.id);
+    }
+
     return this.monitoringRepo.findEventsByExam(examId);
   }
 
@@ -86,5 +139,19 @@ export class MonitoringService {
       body: `A ${eventType} event was reported during an active exam session.`,
       type: 'suspicious_event',
     });
+  }
+
+  private async ensureTeacherOwnsExam(examId: string, teacherId: string) {
+    const exam = await this.examRepo.findExamById(examId);
+
+    if (!exam) {
+      throw new NotFoundException('Exam not found');
+    }
+
+    if (exam.teacherId !== teacherId) {
+      throw new ForbiddenException('You cannot access monitoring for this exam');
+    }
+
+    return exam;
   }
 }


### PR DESCRIPTION
## Summary

Added access control for monitoring-related API operations to restrict visibility and actions to authorized users.

## Problem

The API did not enforce access control for monitoring features, which could allow unauthorized users to access sensitive monitoring data or actions.

## Changes

* Added access control for monitoring-related operations
* Restricted monitoring access based on authorization rules
* Integrated the access checks into the monitoring flow
* Improved security for monitoring endpoints and resolvers

## How to Test

Steps to verify the change:

1. Pull the branch and install dependencies
2. Run the backend application
3. Access monitoring-related endpoints or resolvers with an authorized user
4. Verify access is allowed for permitted users
5. Verify unauthorized users are blocked from accessing monitoring features

## Issue

Closes #122 