### PR TITLE
feat(api): add question ownership rules

### DIFF
--- a/api/src/modules/question/question.controller.ts
+++ b/api/src/modules/question/question.controller.ts
@@ -6,57 +6,89 @@ import {
   Delete,
   Param,
   Body,
+  UseGuards,
 } from '@nestjs/common';
 import { QuestionService } from './question.service';
 import { CreateQuestionDto } from './dto/create-question.dto';
 import { UpdateQuestionDto } from './dto/update-question.dto';
 import { ReorderQuestionsDto } from './dto/reorder-questions.dto';
 import { ReorderOptionsDto } from './dto/reorder-options.dto';
+import { ClerkAuthGuard } from 'src/modules/auth/guards/clerk-auth.guard';
+import { RolesGuard } from 'src/modules/auth/guards/roles.guard';
+import { Roles } from 'src/modules/auth/decorators/roles.decorator';
+import { CurrentUser } from 'src/modules/auth/decorators/current-user.decorator';
+import type { AuthenticatedUser } from 'src/modules/auth/interfaces/authenticated-user.interface';
 
 @Controller('questions')
+@UseGuards(ClerkAuthGuard, RolesGuard)
 export class QuestionController {
   constructor(private readonly questionService: QuestionService) {}
 
   @Get('exam/:examId')
-  getQuestionsByExam(@Param('examId') examId: string) {
-    return this.questionService.getQuestionsByExam(examId);
+  @Roles('teacher', 'student')
+  getQuestionsByExam(
+    @Param('examId') examId: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.questionService.getQuestionsByExam(examId, user);
   }
 
   @Get(':id')
-  getQuestionById(@Param('id') id: string) {
-    return this.questionService.getQuestionById(id);
+  @Roles('teacher', 'student')
+  getQuestionById(
+    @Param('id') id: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.questionService.getQuestionById(id, user);
   }
 
   @Post()
-  createQuestion(@Body() body: CreateQuestionDto) {
+  @Roles('teacher')
+  createQuestion(
+    @Body() body: CreateQuestionDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
     return this.questionService.createQuestion({
       ...body,
       id: crypto.randomUUID(),
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
-    });
+    }, user.id);
   }
 
   @Patch(':id')
-  updateQuestion(@Param('id') id: string, @Body() body: UpdateQuestionDto) {
-    return this.questionService.updateQuestion(id, body);
+  @Roles('teacher')
+  updateQuestion(
+    @Param('id') id: string,
+    @Body() body: UpdateQuestionDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.questionService.updateQuestion(id, body, user.id);
   }
 
   @Delete(':id')
-  deleteQuestion(@Param('id') id: string) {
-    return this.questionService.deleteQuestion(id);
+  @Roles('teacher')
+  deleteQuestion(@Param('id') id: string, @CurrentUser() user: AuthenticatedUser) {
+    return this.questionService.deleteQuestion(id, user.id);
   }
 
   @Patch('exam/:examId/reorder')
+  @Roles('teacher')
   reorderQuestions(
     @Param('examId') examId: string,
     @Body() body: ReorderQuestionsDto,
+    @CurrentUser() user: AuthenticatedUser,
   ) {
-    return this.questionService.reorderQuestions(examId, body.orderedIds);
+    return this.questionService.reorderQuestions(examId, body.orderedIds, user.id);
   }
 
   @Patch(':id/options/reorder')
-  reorderOptions(@Param('id') id: string, @Body() body: ReorderOptionsDto) {
-    return this.questionService.reorderOptions(id, body.options);
+  @Roles('teacher')
+  reorderOptions(
+    @Param('id') id: string,
+    @Body() body: ReorderOptionsDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.questionService.reorderOptions(id, body.options, user.id);
   }
 }

--- a/api/src/modules/question/question.service.ts
+++ b/api/src/modules/question/question.service.ts
@@ -1,34 +1,129 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { QuestionRepository } from './question.repository';
 import { NewQuestion, UpdateQuestion } from 'src/shared/types';
+import type { AuthenticatedUser } from 'src/modules/auth/interfaces/authenticated-user.interface';
+import { ExamRepository } from '../exam/exam.repository';
+import { EnrollmentRepository } from '../enrollment/enrollment.repository';
 
 @Injectable()
 export class QuestionService {
-  constructor(private readonly questionRepo: QuestionRepository) {}
-  async getQuestionsByExam(examId: string) {
+  constructor(
+    private readonly questionRepo: QuestionRepository,
+    private readonly examRepo: ExamRepository,
+    private readonly enrollmentRepo: EnrollmentRepository,
+  ) {}
+  async getQuestionsByExam(examId: string, user?: AuthenticatedUser) {
+    if (user) {
+      await this.ensureExamAccess(examId, user);
+    }
+
     return this.questionRepo.findQuestionsByExam(examId);
   }
-  async getQuestionById(id: string) {
+  async getQuestionById(id: string, user?: AuthenticatedUser) {
     const question = await this.questionRepo.findQuestionById(id);
     if (!question) throw new NotFoundException('Question not found');
+
+    if (user) {
+      await this.ensureExamAccess(question.examId, user);
+    }
+
     return question;
   }
-  async createQuestion(data: NewQuestion) {
+  async createQuestion(data: NewQuestion, teacherId: string) {
+    await this.ensureTeacherCanManageExam(data.examId, teacherId);
     return this.questionRepo.createQuestion(data);
   }
-  async updateQuestion(id: string, data: UpdateQuestion) {
-    await this.getQuestionById(id);
+  async updateQuestion(id: string, data: UpdateQuestion, teacherId: string) {
+    await this.getQuestionForTeacher(id, teacherId);
     return this.questionRepo.updateQuestion(id, data);
   }
-  async deleteQuestion(id: string) {
-    await this.getQuestionById(id);
+  async deleteQuestion(id: string, teacherId: string) {
+    await this.getQuestionForTeacher(id, teacherId);
     return this.questionRepo.deleteQuestion(id);
   }
-  async reorderQuestions(examId: string, orderedIds: string[]) {
+  async reorderQuestions(examId: string, orderedIds: string[], teacherId: string) {
+    await this.ensureTeacherCanManageExam(examId, teacherId);
+    const existingQuestions = await this.questionRepo.findQuestionsByExam(examId);
+
+    if (existingQuestions.length !== orderedIds.length) {
+      throw new BadRequestException(
+        'Ordered question list must include every question in the exam',
+      );
+    }
+
+    const existingIds = new Set(existingQuestions.map((question) => question.id));
+    const hasUnknownIds = orderedIds.some((id) => !existingIds.has(id));
+
+    if (hasUnknownIds) {
+      throw new BadRequestException('Question reorder payload contains invalid ids');
+    }
+
     return this.questionRepo.reorderQuestions(examId, orderedIds);
   }
-  async reorderOptions(id: string, orderedOptions: string[]) {
-    await this.getQuestionById(id);
+  async reorderOptions(id: string, orderedOptions: string[], teacherId: string) {
+    await this.getQuestionForTeacher(id, teacherId);
     return this.questionRepo.reorderOptions(id, orderedOptions);
+  }
+
+  private async getQuestionForTeacher(id: string, teacherId: string) {
+    const question = await this.questionRepo.findQuestionById(id);
+
+    if (!question) {
+      throw new NotFoundException('Question not found');
+    }
+
+    await this.ensureTeacherCanManageExam(question.examId, teacherId);
+
+    return question;
+  }
+
+  private async ensureExamAccess(examId: string, user: AuthenticatedUser) {
+    const exam = await this.examRepo.findExamById(examId);
+
+    if (!exam) {
+      throw new NotFoundException('Exam not found');
+    }
+
+    if (user.role === 'teacher') {
+      if (exam.teacherId !== user.id) {
+        throw new ForbiddenException('You cannot access questions for this exam');
+      }
+
+      return exam;
+    }
+
+    const enrollments = await this.enrollmentRepo.findEnrollmentsByStudent(user.id);
+    const isEnrolled = enrollments.some((enrollment) => enrollment.examId === examId);
+
+    if (!isEnrolled) {
+      throw new ForbiddenException('You are not enrolled in this exam');
+    }
+
+    return exam;
+  }
+
+  private async ensureTeacherCanManageExam(examId: string, teacherId: string) {
+    const exam = await this.examRepo.findExamById(examId);
+
+    if (!exam) {
+      throw new NotFoundException('Exam not found');
+    }
+
+    if (exam.teacherId !== teacherId) {
+      throw new ForbiddenException('You cannot modify this exam');
+    }
+
+    if (exam.status === 'published' || exam.status === 'closed') {
+      throw new BadRequestException(
+        'Questions cannot be modified after the exam is published',
+      );
+    }
+
+    return exam;
   }
 }


### PR DESCRIPTION
## Summary

Added question ownership rules to enforce access and modification permissions for question-related operations.

## Problem

The API did not validate ownership for question-related actions, which could allow unauthorized users to access or modify questions they do not own.

## Changes

* Added question ownership validation rules
* Enforced ownership checks for question-related operations
* Integrated the rules into the question flow
* Improved access control and data protection for question management

## How to Test

Steps to verify the change:

1. Pull the branch and install dependencies
2. Run the backend application
3. Perform question-related actions as the question owner
4. Verify allowed actions succeed
5. Perform the same actions as a different user
6. Verify unauthorized actions are blocked

## Issue

Closes #124 