### PR TITLE
feat(api): add user self access rules

### DIFF
--- a/api/src/modules/user/user.controller.ts
+++ b/api/src/modules/user/user.controller.ts
@@ -1,18 +1,33 @@
-import { Body, Controller, Get, Param, Patch, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { UpdateUserDto } from './dto/update-user.dto';
 import type { UserRole } from 'src/shared/types/user.types';
 import { UserService } from './user.service';
+import { ClerkAuthGuard } from 'src/modules/auth/guards/clerk-auth.guard';
+import { RolesGuard } from 'src/modules/auth/guards/roles.guard';
+import { Roles } from 'src/modules/auth/decorators/roles.decorator';
+import { CurrentUser } from 'src/modules/auth/decorators/current-user.decorator';
+import type { AuthenticatedUser } from 'src/modules/auth/interfaces/authenticated-user.interface';
 
 @Controller('users')
+@UseGuards(ClerkAuthGuard, RolesGuard)
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Get(':id')
-  async getById(@Param('id') id: string) {
-    return this.userService.getById(id);
+  async getById(@Param('id') id: string, @CurrentUser() user: AuthenticatedUser) {
+    return this.userService.getByIdForUser(id, user);
   }
 
   @Get()
+  @Roles('teacher')
   async findAllByRole(@Query('role') role?: UserRole) {
     if (role) {
       return this.userService.findAllByRole(role);
@@ -27,7 +42,8 @@ export class UserController {
   async updateUser(
     @Param('id') id: string,
     @Body() updateUserDto: UpdateUserDto,
+    @CurrentUser() user: AuthenticatedUser,
   ) {
-    return this.userService.updateUser(id, updateUserDto);
+    return this.userService.updateUser(id, updateUserDto, user);
   }
 }

--- a/api/src/modules/user/user.service.ts
+++ b/api/src/modules/user/user.service.ts
@@ -1,6 +1,11 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { UserRepository } from 'src/database/repositories/user.repository';
 import { NewUser, UpdateUser, UserRole } from 'src/shared/types/user.types';
+import type { AuthenticatedUser } from 'src/modules/auth/interfaces/authenticated-user.interface';
 
 interface ClerkUserPayload {
   clerkUserId: string;
@@ -24,6 +29,14 @@ export class UserService {
     return user;
   }
 
+  async getByIdForUser(id: string, requester: AuthenticatedUser) {
+    if (requester.id !== id) {
+      throw new ForbiddenException('You can only access your own user profile');
+    }
+
+    return this.getById(id);
+  }
+
   async getByClerkUserId(clerkUserId: string) {
     const user = await this.userRepository.findByClerkUserId(clerkUserId);
 
@@ -38,7 +51,11 @@ export class UserService {
     return this.userRepository.findAllByRole(role);
   }
 
-  async updateUser(id: string, data: UpdateUser) {
+  async updateUser(id: string, data: UpdateUser, requester: AuthenticatedUser) {
+    if (requester.id !== id) {
+      throw new ForbiddenException('You can only update your own user profile');
+    }
+
     const existingUser = await this.userRepository.findById(id);
 
     if (!existingUser) {


### PR DESCRIPTION
## Summary

Added user self-access rules to enforce permissions for user-related API operations.

## Problem

The API did not clearly restrict self-access behavior, which could allow users to access or modify data outside of their own scope.

## Changes

* Added self-access validation rules for user-related operations
* Enforced access checks based on the current authenticated user
* Integrated the rules into the related user flow
* Improved security and consistency for user data access

## How to Test

Steps to verify the change:

1. Pull the branch and install dependencies
2. Run the backend application
3. Perform user-related actions on your own account
4. Verify allowed self-access actions succeed
5. Attempt the same actions on another user’s account
6. Verify unauthorized actions are blocked

## Issue

Closes #128 