### PR TITLE
fix(api): answer autosave session expiry

### DIFF
--- a/api/src/modules/answer/answer.repository.ts
+++ b/api/src/modules/answer/answer.repository.ts
@@ -1,19 +1,22 @@
 import { Injectable } from '@nestjs/common';
 import { and, desc, eq } from 'drizzle-orm';
 import { db } from 'src/database/client';
-import { answers } from 'src/database/schema';
-import type { NewAnswer } from 'src/shared/types';
+import { answers } from 'src/database/schema/sessions.schema';
+import type { Answer, NewAnswer } from 'src/shared/types/answer.types';
 
 @Injectable()
 export class AnswerRepository {
-  async findAnswersBySession(sessionId: string) {
+  async findAnswersBySession(sessionId: string): Promise<Answer[]> {
     return db.query.answers.findMany({
       where: eq(answers.sessionId, sessionId),
       orderBy: desc(answers.lastSavedAt),
     });
   }
 
-  async findAnswerByQuestion(sessionId: string, questionId: string) {
+  async findAnswerByQuestion(
+    sessionId: string,
+    questionId: string,
+  ): Promise<Answer | undefined> {
     return db.query.answers.findFirst({
       where: and(
         eq(answers.sessionId, sessionId),
@@ -44,7 +47,7 @@ export class AnswerRepository {
       return answer;
     }
 
-    const [answer] = await db.insert(answers).values(data as NewAnswer).returning();
+    const [answer] = await db.insert(answers).values(data).returning();
     return answer;
   }
 

--- a/api/src/modules/answer/answer.service.ts
+++ b/api/src/modules/answer/answer.service.ts
@@ -6,10 +6,12 @@ import {
 } from '@nestjs/common';
 import { AnswerRepository } from './answer.repository';
 import { SessionRepository } from '../session/session.repository';
-import type { NewAnswer } from 'src/shared/types';
+import type { NewAnswer } from 'src/shared/types/answer.types';
 import type { AuthenticatedUser } from 'src/modules/auth/interfaces/authenticated-user.interface';
 import { QuestionRepository } from '../question/question.repository';
 import { ExamRepository } from '../exam/exam.repository';
+import { SessionService } from '../session/session.service';
+import { getSessionTiming } from 'src/shared/utils/exam-session';
 
 @Injectable()
 export class AnswerService {
@@ -18,6 +20,7 @@ export class AnswerService {
     private readonly sessionRepo: SessionRepository,
     private readonly questionRepo: QuestionRepository,
     private readonly examRepo: ExamRepository,
+    private readonly sessionService: SessionService,
   ) {}
 
   async getAnswersBySession(sessionId: string, user: AuthenticatedUser) {
@@ -25,13 +28,16 @@ export class AnswerService {
     return this.answerRepo.findAnswersBySession(sessionId);
   }
 
-  async autosaveAnswer(data: {
-    sessionId: string;
-    questionId: string;
-    textAnswer?: string;
-    formulaAnswerJson?: string;
-    fileUrl?: string;
-  }, user: AuthenticatedUser) {
+  async autosaveAnswer(
+    data: {
+      sessionId: string;
+      questionId: string;
+      textAnswer?: string;
+      formulaAnswerJson?: string;
+      fileUrl?: string;
+    },
+    user: AuthenticatedUser,
+  ) {
     const session = await this.ensureSessionAccess(data.sessionId, user, true);
     const question = await this.questionRepo.findQuestionById(data.questionId);
 
@@ -40,7 +46,9 @@ export class AnswerService {
     }
 
     if (question.examId !== session.examId) {
-      throw new BadRequestException('Question does not belong to this session exam');
+      throw new BadRequestException(
+        'Question does not belong to this session exam',
+      );
     }
 
     const now = new Date().toISOString();
@@ -79,7 +87,9 @@ export class AnswerService {
       const exam = await this.examRepo.findExamById(session.examId);
 
       if (!exam || exam.teacherId !== user.id) {
-        throw new ForbiddenException('You cannot access answers for this session');
+        throw new ForbiddenException(
+          'You cannot access answers for this session',
+        );
       }
 
       if (requireWritable) {
@@ -95,11 +105,29 @@ export class AnswerService {
 
     if (requireWritable) {
       if (session.status !== 'in_progress') {
-        throw new BadRequestException('Answers can only be changed during an active session');
+        throw new BadRequestException(
+          'Answers can only be changed during an active session',
+        );
       }
 
       if (session.submittedAt) {
         throw new BadRequestException('Submitted sessions cannot be changed');
+      }
+
+      const exam = await this.examRepo.findExamById(session.examId);
+
+      if (!exam) {
+        throw new NotFoundException('Exam not found');
+      }
+
+      const timing = getSessionTiming(exam, session);
+
+      if (timing.isExpired) {
+        await this.sessionService.forceSubmitSession(
+          session.id,
+          'time_expired',
+        );
+        throw new BadRequestException('Session time has expired');
       }
     }
 


### PR DESCRIPTION
## Summary

Prevent answer autosave from updating expired exam sessions and force-submit sessions once their allowed time has run out.

## Problem

Students can continue sending autosave requests after a session has expired, which can allow late answer updates and leave the session state out of sync with the exam timing rules.

## Changes

* Check session timing before accepting an autosave request
* Force-submit an in-progress session when its time limit has expired
* Tighten answer repository typing and answer schema imports for session answer access

## How to Test

Steps to verify the change:

1. Start an exam session and autosave an answer before the session expires.
2. Wait until the session passes its expiry time and send another autosave request.
3. Confirm the request is rejected and the session is marked as `force_submitted`.

## Issue

Closes #141 
