### PR TITLE
refactor(api): auth token request typing

### DIFF
--- a/api/src/modules/auth/auth.service.ts
+++ b/api/src/modules/auth/auth.service.ts
@@ -1,6 +1,30 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { UserService } from 'src/modules/user/user.service';
 
+interface ClerkTokenPayload {
+  sub: string;
+  email: string;
+  name?: string;
+  imageUrl?: string | null;
+}
+
+function isClerkTokenPayload(value: unknown): value is ClerkTokenPayload {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const payload = value as Record<string, unknown>;
+
+  return (
+    typeof payload.sub === 'string' &&
+    typeof payload.email === 'string' &&
+    (payload.name === undefined || typeof payload.name === 'string') &&
+    (payload.imageUrl === undefined ||
+      payload.imageUrl === null ||
+      typeof payload.imageUrl === 'string')
+  );
+}
+
 @Injectable()
 export class AuthService {
   constructor(private readonly userService: UserService) {}
@@ -12,7 +36,7 @@ export class AuthService {
 
     const token = authHeader.replace('Bearer ', '');
 
-    let payload: any;
+    let payload: unknown;
 
     try {
       payload = JSON.parse(Buffer.from(token, 'base64').toString());
@@ -20,11 +44,11 @@ export class AuthService {
       throw new UnauthorizedException('Invalid token format');
     }
 
-    const { sub, email, name, imageUrl } = payload;
-
-    if (!sub || !email) {
+    if (!isClerkTokenPayload(payload)) {
       throw new UnauthorizedException('Invalid token payload');
     }
+
+    const { sub, email, name, imageUrl } = payload;
 
     const user = await this.userService.findOrCreateFromClerk({
       clerkUserId: sub,

--- a/api/src/modules/auth/decorators/current-user.decorator.ts
+++ b/api/src/modules/auth/decorators/current-user.decorator.ts
@@ -1,9 +1,21 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
-import { AuthenticatedUser } from '../interfaces/authenticated-user.interface';
+import {
+  createParamDecorator,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { AuthenticatedUser } from '../interfaces/authenticated-user.interface';
+import type { AuthenticatedRequest } from '../interfaces/authenticated-request.interface';
 
 export const CurrentUser = createParamDecorator(
   (_data: unknown, context: ExecutionContext): AuthenticatedUser => {
-    const request = context.switchToHttp().getRequest();
-    return request.user as AuthenticatedUser;
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+
+    if (!request.user) {
+      throw new UnauthorizedException(
+        'Authenticated user missing from request',
+      );
+    }
+
+    return request.user;
   },
 );

--- a/api/src/modules/auth/guards/clerk-auth.guard.ts
+++ b/api/src/modules/auth/guards/clerk-auth.guard.ts
@@ -1,14 +1,14 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthService } from '../auth.service';
+import type { AuthenticatedRequest } from '../interfaces/authenticated-request.interface';
 
 @Injectable()
 export class ClerkAuthGuard implements CanActivate {
   constructor(private readonly authService: AuthService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request = context.switchToHttp().getRequest();
-
-    const authHeader = request.headers['authorization'];
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const authHeader = request.header('authorization');
 
     const user = await this.authService.validateRequest(authHeader);
 

--- a/api/src/modules/auth/guards/roles.guard.ts
+++ b/api/src/modules/auth/guards/roles.guard.ts
@@ -6,8 +6,8 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ROLES_KEY } from '../decorators/roles.decorator';
-import { UserRole } from 'src/shared/types/user.types';
-import { AuthenticatedUser } from '../interfaces/authenticated-user.interface';
+import type { UserRole } from 'src/shared/types/user.types';
+import type { AuthenticatedRequest } from '../interfaces/authenticated-request.interface';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
@@ -23,8 +23,8 @@ export class RolesGuard implements CanActivate {
       return true;
     }
 
-    const request = context.switchToHttp().getRequest();
-    const user = request.user as AuthenticatedUser | undefined;
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const { user } = request;
 
     if (!user) {
       throw new ForbiddenException('User not found in request');

--- a/api/src/modules/auth/interfaces/authenticated-request.interface.ts
+++ b/api/src/modules/auth/interfaces/authenticated-request.interface.ts
@@ -1,0 +1,6 @@
+import type { Request } from 'express';
+import type { AuthenticatedUser } from './authenticated-user.interface';
+
+export interface AuthenticatedRequest extends Request {
+  user?: AuthenticatedUser;
+}


### PR DESCRIPTION
## Summary

Refactor the API auth layer to use safer typing for decoded auth tokens and authenticated requests.

## Problem

The auth flow relies on loosely typed request and token data, which makes it easier for invalid payloads to pass through and harder to reason about authenticated user access safely.

## Changes

* Replace loose token payload handling with an explicit Clerk token payload type guard
* Add a typed authenticated request interface for request-level user access
* Update auth decorators and guards to use typed request/user access and fail clearly when auth data is missing

## How to Test

Steps to verify the change:

1. Send a request with a valid authorization token and confirm the authenticated user is resolved correctly.
2. Send a request with an invalid or malformed token payload and confirm the API returns an unauthorized error.
3. Hit a guarded route and verify decorators and guards can read the typed authenticated user from the request.

## Issue

Closes #142 
