### PR TITLE
refactor(api): enrollment repository types

### DIFF
--- a/api/src/modules/enrollment/enrollment.repository.ts
+++ b/api/src/modules/enrollment/enrollment.repository.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { eq, and } from 'drizzle-orm';
 import { db } from 'src/database/client';
-import { examEnrollments } from 'src/database/schema';
+import { examEnrollments } from 'src/database/schema/exams.schema';
+import type { Enrollment } from 'src/shared/types/enrollment.types';
 
 @Injectable()
 export class EnrollmentRepository {
-  async enrollStudent(examId: string, studentId: string) {
+  async enrollStudent(examId: string, studentId: string): Promise<Enrollment> {
     const [enrollment] = await db
       .insert(examEnrollments)
       .values({
@@ -18,13 +19,13 @@ export class EnrollmentRepository {
     return enrollment;
   }
 
-  async findEnrollmentsByExam(examId: string) {
+  async findEnrollmentsByExam(examId: string): Promise<Enrollment[]> {
     return db.query.examEnrollments.findMany({
       where: eq(examEnrollments.examId, examId),
     });
   }
 
-  async findEnrollmentsByStudent(studentId: string) {
+  async findEnrollmentsByStudent(studentId: string): Promise<Enrollment[]> {
     return db.query.examEnrollments.findMany({
       where: eq(examEnrollments.studentId, studentId),
     });


### PR DESCRIPTION
## Summary

Strengthen enrollment repository typing and align its schema imports with the newer schema structure.

## Problem

The enrollment repository returns untyped data and imports from a broader schema entrypoint, which makes type usage less explicit and harder to maintain.

## Changes

* Add shared enrollment types for insert and select models
* Import enrollment schema definitions from `exams.schema`
* Add explicit return types to enrollment repository methods

## How to Test

Steps to verify the change:

1. Run the API type checks.
2. Exercise the enrollment flow through existing exam assignment endpoints or services.
3. Confirm enrollment repository consumers compile and return the expected typed data.

## Issue

Closes #144 