### PR TITLE
feat(api): add student assigned exams

### DIFF
--- a/api/src/modules/exam/exam.controller.ts
+++ b/api/src/modules/exam/exam.controller.ts
@@ -23,6 +23,12 @@ import type { AuthenticatedUser } from 'src/modules/auth/interfaces/authenticate
 export class ExamController {
   constructor(private readonly examService: ExamService) {}
 
+  @Get('assigned/me')
+  @Roles('student')
+  getAssignedExams(@CurrentUser() user: AuthenticatedUser) {
+    return this.examService.getAssignedExams(user.id);
+  }
+
   @Get()
   getMyExams(@CurrentUser() user: AuthenticatedUser) {
     return this.examService.getMyExams(user.id);

--- a/api/src/modules/exam/exam.repository.ts
+++ b/api/src/modules/exam/exam.repository.ts
@@ -1,32 +1,45 @@
 import { Injectable } from '@nestjs/common';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { db } from 'src/database/client';
-import { exams } from 'src/database/schema';
-import type { ExamStatus, NewExam } from 'src/shared/types';
+import { exams } from 'src/database/schema/exams.schema';
+import type { Exam, ExamStatus, NewExam } from 'src/shared/types/exam.types';
 
 @Injectable()
 export class ExamRepository {
-  async findAllExams(filters?: { status?: ExamStatus }) {
+  async findAllExams(filters?: { status?: ExamStatus }): Promise<Exam[]> {
     return db.query.exams.findMany({
       where: filters?.status ? eq(exams.status, filters.status) : undefined,
     });
   }
 
-  async findExamById(id: string) {
+  async findExamById(id: string): Promise<Exam | undefined> {
     return db.query.exams.findFirst({
       where: eq(exams.id, id),
     });
   }
 
-  async findExamByIdAndTeacherId(id: string, teacherId: string) {
+  async findExamByIdAndTeacherId(
+    id: string,
+    teacherId: string,
+  ): Promise<Exam | undefined> {
     return db.query.exams.findFirst({
       where: and(eq(exams.id, id), eq(exams.teacherId, teacherId)),
     });
   }
 
-  async findExamsByTeacher(teacherId: string) {
+  async findExamsByTeacher(teacherId: string): Promise<Exam[]> {
     return db.query.exams.findMany({
       where: eq(exams.teacherId, teacherId),
+    });
+  }
+
+  async findExamsByIds(ids: string[]): Promise<Exam[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+
+    return db.query.exams.findMany({
+      where: inArray(exams.id, ids),
     });
   }
 

--- a/api/src/modules/exam/exam.service.ts
+++ b/api/src/modules/exam/exam.service.ts
@@ -5,16 +5,25 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 
-import { NewExam, ExamStatus } from 'src/shared/types/exam.types';
+import type { NewExam, ExamStatus } from 'src/shared/types/exam.types';
+import type {
+  AssignedExamSummary,
+  Session,
+} from 'src/shared/types/session.types';
 import { ExamRepository } from './exam.repository';
 import { CreateExamDto } from './dto/create-exam.dto';
 import { QuestionRepository } from '../question/question.repository';
+import { EnrollmentRepository } from '../enrollment/enrollment.repository';
+import { SessionRepository } from '../session/session.repository';
+import { getSessionTiming } from 'src/shared/utils/exam-session';
 
 @Injectable()
 export class ExamService {
   constructor(
     private readonly examRepo: ExamRepository,
     private readonly questionRepo: QuestionRepository,
+    private readonly enrollmentRepo: EnrollmentRepository,
+    private readonly sessionRepo: SessionRepository,
   ) {}
 
   async getAllExams() {
@@ -33,6 +42,53 @@ export class ExamService {
 
   async getExamsByTeacher(teacherId: string) {
     return this.examRepo.findExamsByTeacher(teacherId);
+  }
+
+  async getAssignedExams(studentId: string): Promise<AssignedExamSummary[]> {
+    const enrollments =
+      await this.enrollmentRepo.findEnrollmentsByStudent(studentId);
+
+    if (enrollments.length === 0) {
+      return [];
+    }
+
+    const [exams, sessions] = await Promise.all([
+      this.examRepo.findExamsByIds(
+        enrollments.map((enrollment) => enrollment.examId),
+      ),
+      this.sessionRepo.findSessionsByStudent(studentId),
+    ]);
+
+    const examById = new Map(exams.map((exam) => [exam.id, exam]));
+    const latestSessionByExam = new Map<string, Session>();
+
+    for (const session of sessions) {
+      if (!latestSessionByExam.has(session.examId)) {
+        latestSessionByExam.set(session.examId, session);
+      }
+    }
+
+    const summaries: AssignedExamSummary[] = [];
+
+    for (const enrollment of enrollments) {
+      const exam = examById.get(enrollment.examId);
+
+      if (!exam) {
+        continue;
+      }
+
+      const session = latestSessionByExam.get(enrollment.examId) ?? null;
+
+      summaries.push({
+        exam,
+        session,
+        enrolledAt: enrollment.assignedAt,
+        attemptStatus: this.getAssignedExamStatus(exam, session),
+        timing: session?.startedAt ? getSessionTiming(exam, session) : null,
+      });
+    }
+
+    return summaries;
   }
 
   async createExam(teacherId: string, dto: CreateExamDto) {
@@ -107,7 +163,10 @@ export class ExamService {
     return this.examRepo.deleteExam(id);
   }
 
-  private validateExamSchedule(startsAt?: string | null, endsAt?: string | null) {
+  private validateExamSchedule(
+    startsAt?: string | null,
+    endsAt?: string | null,
+  ) {
     if (!startsAt || !endsAt) {
       return;
     }
@@ -133,5 +192,46 @@ export class ExamService {
         `Cannot change exam status from ${currentStatus} to ${nextStatus}`,
       );
     }
+  }
+
+  private getAssignedExamStatus(
+    exam: {
+      status: ExamStatus;
+      startsAt: string | null;
+      endsAt: string | null;
+    },
+    session: Session | null,
+  ): AssignedExamSummary['attemptStatus'] {
+    if (session?.status === 'submitted') {
+      return 'submitted';
+    }
+
+    if (session?.status === 'force_submitted') {
+      return 'force_submitted';
+    }
+
+    if (session?.status === 'in_progress') {
+      return 'in_progress';
+    }
+
+    const now = new Date();
+
+    if (exam.status === 'closed') {
+      return 'closed';
+    }
+
+    if (exam.startsAt && now < new Date(exam.startsAt)) {
+      return 'upcoming';
+    }
+
+    if (exam.endsAt && now > new Date(exam.endsAt)) {
+      return 'closed';
+    }
+
+    if (exam.status === 'scheduled' || exam.status === 'published') {
+      return 'ready';
+    }
+
+    return 'closed';
   }
 }


### PR DESCRIPTION
## Summary

Add a student-facing assigned exams endpoint that returns enrollment, session, and attempt status details.

## Problem

Students do not have a dedicated API flow to view only the exams assigned to them or understand whether an exam is upcoming, ready, in progress, submitted, or closed.

## Changes

* Add `GET /exams/assigned/me` for student-assigned exams
* Load assigned exams from enrollments and latest student sessions
* Return attempt status, enrollment time, and timing metadata for each exam

## How to Test

Steps to verify the change:

1. Enroll a student in one or more exams with different schedules and statuses.
2. Call `GET /exams/assigned/me` as that student.
3. Verify the response shows only assigned exams and returns the correct `attemptStatus` and timing data.

## Issue

Closes #145 