### PR TITLE
feat(api): add exam activity notifications

### DIFF
--- a/api/src/modules/notification/notification.service.ts
+++ b/api/src/modules/notification/notification.service.ts
@@ -6,7 +6,9 @@ import type { NewNotification } from 'src/shared/types';
 export class NotificationService {
   constructor(private readonly notificationRepo: NotificationRepository) {}
 
-  async createNotification(data: Omit<NewNotification, 'id' | 'isRead' | 'createdAt'>) {
+  async createNotification(
+    data: Omit<NewNotification, 'id' | 'isRead' | 'createdAt'>,
+  ) {
     const now = new Date().toISOString();
 
     return this.notificationRepo.createNotification({


### PR DESCRIPTION
## Summary

Notify teachers when students start, resume, submit, or are auto-submitted from exam sessions.

## Problem

Teachers do not have immediate visibility into important exam session lifecycle events such as starts, submissions, and automatic submissions.

## Changes

* Send an `exam_started` notification when a session starts or resumes
* Send an `exam_submitted` notification for both manual and forced submissions
* Wire session flow into the notification module for teacher-facing activity alerts

## How to Test

Steps to verify the change:

1. Start or resume a student exam session.
2. Submit the session normally and also verify a force-submit path.
3. Confirm the teacher receives notifications with the correct type, title, and body.

## Issue

Closes #147 
