### PR TITLE
chore(api): main bootstrap call

### DIFF
--- a/api/src/graphql/schema/index.ts
+++ b/api/src/graphql/schema/index.ts
@@ -1,3 +1,5 @@
 import { join } from 'path';
 
-export const graphqlTypePaths = [join(process.cwd(), 'src/graphql/schema/**/*.graphql')];
+export const graphqlTypePaths = [
+  join(process.cwd(), 'src/graphql/schema/**/*.graphql'),
+];

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -21,4 +21,4 @@ async function bootstrap() {
 
   await app.listen(process.env.PORT ?? 3000, '0.0.0.0');
 }
-bootstrap();
+void bootstrap();

--- a/api/src/shared/types/answer.types.ts
+++ b/api/src/shared/types/answer.types.ts
@@ -1,5 +1,5 @@
 import { InferInsertModel, InferSelectModel } from 'drizzle-orm';
-import { answers } from 'src/database/schema';
+import { answers } from 'src/database/schema/sessions.schema';
 
 export type Answer = InferSelectModel<typeof answers>;
 export type NewAnswer = InferInsertModel<typeof answers>;

--- a/api/src/shared/types/enrollment.types.ts
+++ b/api/src/shared/types/enrollment.types.ts
@@ -1,0 +1,5 @@
+import { InferInsertModel, InferSelectModel } from 'drizzle-orm';
+import { examEnrollments } from 'src/database/schema/exams.schema';
+
+export type Enrollment = InferSelectModel<typeof examEnrollments>;
+export type NewEnrollment = InferInsertModel<typeof examEnrollments>;

--- a/api/src/shared/types/exam.types.ts
+++ b/api/src/shared/types/exam.types.ts
@@ -1,5 +1,5 @@
 import { InferSelectModel, InferInsertModel } from 'drizzle-orm';
-import { exams } from 'src/database/schema';
+import { exams } from 'src/database/schema/exams.schema';
 
 export type Exam = InferSelectModel<typeof exams>;
 export type NewExam = InferInsertModel<typeof exams>;

--- a/api/src/shared/types/index.ts
+++ b/api/src/shared/types/index.ts
@@ -1,4 +1,5 @@
 export * from './answer.types';
+export * from './enrollment.types';
 export * from './exam.types';
 export * from './notification.types';
 export * from './monitoring.types';

--- a/api/src/shared/types/question.types.ts
+++ b/api/src/shared/types/question.types.ts
@@ -1,8 +1,11 @@
 import { InferSelectModel, InferInsertModel } from 'drizzle-orm';
-import { questions } from 'src/database/schema';
+import { questions } from 'src/database/schema/questions.schema';
 
 export type Question = InferSelectModel<typeof questions>;
 export type NewQuestion = InferInsertModel<typeof questions>;
+export type StudentQuestion = Omit<Question, 'correctAnswer'> & {
+  correctAnswer: null;
+};
 export type UpdateQuestion = Partial<
   Omit<NewQuestion, 'id' | 'examId' | 'createdAt'>
 >;

--- a/api/src/shared/types/session.types.ts
+++ b/api/src/shared/types/session.types.ts
@@ -1,5 +1,8 @@
 import { InferInsertModel, InferSelectModel } from 'drizzle-orm';
-import { examSessions } from 'src/database/schema';
+import { examSessions } from 'src/database/schema/sessions.schema';
+import type { Answer } from './answer.types';
+import type { Exam } from './exam.types';
+import type { Question, StudentQuestion } from './question.types';
 
 export type Session = InferSelectModel<typeof examSessions>;
 export type NewSession = InferInsertModel<typeof examSessions>;
@@ -7,3 +10,42 @@ export type UpdateSession = Partial<
   Omit<NewSession, 'id' | 'examId' | 'studentId' | 'createdAt'>
 >;
 export type SessionStatus = Session['status'];
+
+export interface SessionTiming {
+  serverTime: string;
+  startedAt: string | null;
+  expiresAt: string | null;
+  timeLimitMinutes: number;
+  timeRemainingSeconds: number;
+  isExpired: boolean;
+}
+
+export interface SessionAttempt {
+  exam: Exam;
+  session: Session;
+  questions: StudentQuestion[];
+  answers: Answer[];
+  timing: SessionTiming;
+}
+
+export interface TeacherSessionAttempt {
+  exam: Exam;
+  session: Session;
+  questions: Question[];
+  answers: Answer[];
+  timing: SessionTiming;
+}
+
+export interface AssignedExamSummary {
+  exam: Exam;
+  session: Session | null;
+  enrolledAt: string;
+  attemptStatus:
+    | 'upcoming'
+    | 'ready'
+    | 'in_progress'
+    | 'submitted'
+    | 'force_submitted'
+    | 'closed';
+  timing: SessionTiming | null;
+}

--- a/api/src/shared/utils/exam-session.spec.ts
+++ b/api/src/shared/utils/exam-session.spec.ts
@@ -1,0 +1,55 @@
+import { getSessionTiming, isAnswerProvided } from './exam-session';
+
+describe('exam-session utils', () => {
+  it('uses the earlier of duration limit and exam end time', () => {
+    const exam = {
+      durationMinutes: 60,
+      endsAt: '2026-03-30T10:30:00.000Z',
+    };
+    const session = {
+      startedAt: '2026-03-30T10:00:00.000Z',
+    };
+    const now = new Date('2026-03-30T10:10:00.000Z');
+
+    const timing = getSessionTiming(exam, session, now);
+
+    expect(timing.expiresAt).toBe('2026-03-30T10:30:00.000Z');
+    expect(timing.timeRemainingSeconds).toBe(20 * 60);
+    expect(timing.isExpired).toBe(false);
+  });
+
+  it('marks the session expired when the duration is exhausted', () => {
+    const exam = {
+      durationMinutes: 30,
+      endsAt: null,
+    };
+    const session = {
+      startedAt: '2026-03-30T10:00:00.000Z',
+    };
+    const now = new Date('2026-03-30T10:31:00.000Z');
+
+    const timing = getSessionTiming(exam, session, now);
+
+    expect(timing.expiresAt).toBe('2026-03-30T10:30:00.000Z');
+    expect(timing.timeRemainingSeconds).toBe(0);
+    expect(timing.isExpired).toBe(true);
+  });
+
+  it('treats blank answers as unanswered', () => {
+    expect(
+      isAnswerProvided({
+        textAnswer: '   ',
+        formulaAnswerJson: null,
+        fileUrl: null,
+      }),
+    ).toBe(false);
+
+    expect(
+      isAnswerProvided({
+        textAnswer: null,
+        formulaAnswerJson: null,
+        fileUrl: 'https://example.com/file.png',
+      }),
+    ).toBe(true);
+  });
+});

--- a/api/src/shared/utils/exam-session.ts
+++ b/api/src/shared/utils/exam-session.ts
@@ -1,0 +1,69 @@
+import type { Answer } from 'src/shared/types/answer.types';
+import type { Exam } from 'src/shared/types/exam.types';
+import type { Session, SessionTiming } from 'src/shared/types/session.types';
+
+function toValidDate(input?: string | null) {
+  if (!input) {
+    return null;
+  }
+
+  const date = new Date(input);
+
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function getSessionExpiryDate(
+  exam: Pick<Exam, 'durationMinutes' | 'endsAt'>,
+  session: Pick<Session, 'startedAt'>,
+) {
+  const startedAt = toValidDate(session.startedAt);
+
+  if (!startedAt) {
+    return null;
+  }
+
+  const durationDeadline = new Date(
+    startedAt.getTime() + exam.durationMinutes * 60 * 1000,
+  );
+  const examEnd = toValidDate(exam.endsAt);
+
+  if (!examEnd) {
+    return durationDeadline;
+  }
+
+  return durationDeadline < examEnd ? durationDeadline : examEnd;
+}
+
+export function getSessionTiming(
+  exam: Pick<Exam, 'durationMinutes' | 'endsAt'>,
+  session: Pick<Session, 'startedAt'>,
+  now = new Date(),
+): SessionTiming {
+  const startedAt = session.startedAt ?? null;
+  const expiryDate = getSessionExpiryDate(exam, session);
+  const expiresAt = expiryDate?.toISOString() ?? null;
+  const timeRemainingMs = expiryDate
+    ? Math.max(0, expiryDate.getTime() - now.getTime())
+    : 0;
+
+  return {
+    serverTime: now.toISOString(),
+    startedAt,
+    expiresAt,
+    timeLimitMinutes: exam.durationMinutes,
+    timeRemainingSeconds: Math.ceil(timeRemainingMs / 1000),
+    isExpired: expiryDate ? expiryDate.getTime() <= now.getTime() : false,
+  };
+}
+
+export function isAnswerProvided(
+  answer?: Pick<Answer, 'textAnswer' | 'formulaAnswerJson' | 'fileUrl'> | null,
+) {
+  if (!answer) {
+    return false;
+  }
+
+  return [answer.textAnswer, answer.formulaAnswerJson, answer.fileUrl].some(
+    (value) => typeof value === 'string' && value.trim().length > 0,
+  );
+}

--- a/api/src/shared/utils/index.ts
+++ b/api/src/shared/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './exam-session';


### PR DESCRIPTION
## Summary

Clean up the API bootstrap entrypoint to avoid an unhandled async call warning without changing startup behavior.

## Problem

The bootstrap entrypoint calls an async function directly, which can trigger floating promise warnings and make the startup code less explicit.

## Changes

* Replace the bare `bootstrap()` call with `void bootstrap()`
* Keep the existing Nest app startup flow unchanged
* Align the entrypoint with async call best practices

## How to Test

Steps to verify the change:

1. Start the API server.
2. Confirm the application still boots normally on the configured port.
3. Run lint or type checks and verify there is no floating promise warning for the bootstrap call.

## Issue

Closes #151 
