### PR TITLE
feat(web): add root layout with providers and initial route redirect

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,45 @@
+import type { Metadata, Viewport } from 'next'
+import { Montserrat } from 'next/font/google'
+import { Analytics } from '@vercel/analytics/next'
+import './globals.css'
+import { DataInitializer } from '@/components/data-initializer'
+import { PlatformSwitcher } from '@/components/platform-switcher'
+import { Toaster } from '@/components/ui/toaster'
+
+const montserrat = Montserrat({ 
+  subsets: ['latin', 'cyrillic'],
+  weight: ['400', '500', '600'],
+  variable: '--font-montserrat',
+})
+
+export const metadata: Metadata = {
+  title: 'e-Shalgalt | Үндэсний шалгалтын систем',
+  description: 'Монгол улсын боловсролын үндэсний шалгалт, үнэлгээний платформ',
+  generator: 'v0.app',
+}
+
+export const viewport: Viewport = {
+  themeColor: '#0A2D6E',
+}
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html lang="mn">
+      <body className={`${montserrat.variable} font-sans antialiased`}>
+        <DataInitializer />
+        <div className="min-h-screen flex flex-col">
+          <PlatformSwitcher />
+          <div className="flex-1">
+            {children}
+          </div>
+        </div>
+        <Toaster />
+        <Analytics />
+      </body>
+    </html>
+  )
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function Home() {
+  redirect('/teacher')
+}


### PR DESCRIPTION
## What
- Adds root layout with global providers and app structure
- Integrates font configuration and global styles
- Adds initial routing to redirect root path to /teacher

## Why
The root layout defines the global structure of the application,
including shared components like data initialization, platform switching,
notifications, and analytics. The redirect ensures users land on the
correct entry point when accessing the root URL.

## Files changed
- web/app/layout.tsx
- web/app/page.tsx

## How to test
- Run `yarn dev` → app starts successfully
- Open `/` → redirects to `/teacher`
- Verify layout renders with global components (header, toaster, etc.)

Closes #173