### PR TITLE
feat(web): add useStudentShell hook for student layout state

### DIFF
--- a/web/features/student/student-shell/hooks/useStudentShell.ts
+++ b/web/features/student/student-shell/hooks/useStudentShell.ts
@@ -1,0 +1,15 @@
+import { usePathname } from 'next/navigation'
+
+import { getCurrentStudent } from '@/lib/data'
+
+export function useStudentShell(): {
+  pathname: string
+  isExamPage: boolean
+  studentDisplayName: string
+} {
+  const pathname = usePathname()
+  const isExamPage = Boolean(pathname.match(/\/student\/exams\/[^/]+$/))
+  const studentDisplayName = getCurrentStudent()?.name ?? 'Сурагч'
+
+  return { pathname, isExamPage, studentDisplayName }
+}


### PR DESCRIPTION
## What
- Adds useStudentShell hook to centralize student layout state logic
- Provides pathname, exam page detection, and student display name

## Why
Multiple student layout components require consistent access to routing
state and user information. This hook avoids duplication and ensures
a single source of truth for layout-related logic.

## Files changed
- web/features/student/student-shell/hooks/useStudentShell.ts

## How to test
- Import useStudentShell in a component
- Verify pathname reflects current route
- Navigate to /student/exams/[id] → isExamPage returns true
- Verify studentDisplayName returns current student name or fallback

Closes #177