### PR TITLE
feat(web): add StudentShellFeature layout wrapper for student pages

### DIFF
--- a/web/features/student/student-shell/StudentShellFeature.tsx
+++ b/web/features/student/student-shell/StudentShellFeature.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { StudentTopNav } from '@/features/student/student-shell/components/StudentTopNav'
+import { useStudentShell } from '@/features/student/student-shell/hooks/useStudentShell'
+import { studentNavLinks } from '@/features/student/student-shell/utils/student-shell.constants'
+
+type StudentShellFeatureProps = {
+  children: React.ReactNode
+}
+
+export function StudentShellFeature({ children }: StudentShellFeatureProps) {
+  const { pathname, isExamPage, studentDisplayName } = useStudentShell()
+
+  if (isExamPage) {
+    return <>{children}</>
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <div className="flex-1 bg-page-bg">
+        <StudentTopNav
+          pathname={pathname}
+          navLinks={studentNavLinks}
+          studentDisplayName={studentDisplayName}
+        />
+        <main className="p-6">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What
- Adds StudentShellFeature layout wrapper for student pages
- Integrates StudentTopNav with navigation links and user info
- Handles conditional layout rendering for exam pages

## Why
Student pages require a consistent layout structure with navigation and
content areas. This component centralizes layout logic and ensures that
exam pages can bypass the shell when needed for a focused experience.

## Files changed
- web/features/student/student-shell/StudentShellFeature.tsx

## How to test
- Wrap a student page with StudentShellFeature
- Verify top navigation is displayed on normal pages
- Navigate to /student/exams/[id] → layout is skipped
- Confirm content renders correctly in both cases

## Screenshots

### Student Shell Layout
(Add screenshots showing the layout with navigation and content)

- Default layout view
- Navigation visible with active state
- Exam page (layout hidden)

Closes #183