### PR TITLE
feat(web): add AnswerTrueFalse component for boolean questions

### DIFF
--- a/web/features/student/exam-taking/_components/AnswerTrueFalse.tsx
+++ b/web/features/student/exam-taking/_components/AnswerTrueFalse.tsx
@@ -1,0 +1,50 @@
+import { Check, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface AnswerTrueFalseProps {
+  selected: string
+  onChange: (value: string) => void
+}
+
+export function AnswerTrueFalse({ selected, onChange }: AnswerTrueFalseProps) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <button
+        onClick={() => onChange('true')}
+        className={cn(
+          "p-6 rounded-xl border-2 text-center transition-all",
+          selected === 'true'
+            ? "bg-green-50 border-green-500"
+            : "bg-white border-card-border hover:border-input-border"
+        )}
+      >
+        <Check size={24} className={cn(
+          "mx-auto mb-2",
+          selected === 'true' ? "text-green-500" : "text-card-border"
+        )} strokeWidth={2} />
+        <span className={cn(
+          "text-[16px] font-semibold",
+          selected === 'true' ? "text-green-700" : "text-foreground"
+        )}>Үнэн</span>
+      </button>
+      <button
+        onClick={() => onChange('false')}
+        className={cn(
+          "p-6 rounded-xl border-2 text-center transition-all",
+          selected === 'false'
+            ? "bg-red-50 border-red-400"
+            : "bg-white border-card-border hover:border-input-border"
+        )}
+      >
+        <X size={24} className={cn(
+          "mx-auto mb-2",
+          selected === 'false' ? "text-red-500" : "text-card-border"
+        )} strokeWidth={2} />
+        <span className={cn(
+          "text-[16px] font-semibold",
+          selected === 'false' ? "text-red-700" : "text-foreground"
+        )}>Худал</span>
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## What
- Adds AnswerTrueFalse component for boolean-type exam questions
- Provides selectable true/false options with visual feedback
- Includes active state styling and icon indicators

## Why
True/False questions are a fundamental question type in exams.
This component provides a clear and intuitive interface for selecting
boolean answers while maintaining consistency with other answer components.

## Files changed
- web/features/student/exam-taking/_components/AnswerTrueFalse.tsx

## How to test
- Render AnswerTrueFalse component
- Click "Үнэн" or "Худал" → selection updates correctly
- Verify active state styling changes
- Confirm icons and colors reflect selected state

## Screenshots

### True / False Answer Component

Closes #201