### PR TITLE
feat(web): add useAdminShell hook for admin layout state

### DIFF
--- a/web/features/admin/admin-shell/hooks/useAdminShell.ts
+++ b/web/features/admin/admin-shell/hooks/useAdminShell.ts
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+import { usePathname } from 'next/navigation'
+
+export function useAdminShell(): {
+  pathname: string
+  sidebarOpen: boolean
+  setSidebarOpen: (value: boolean | ((prev: boolean) => boolean)) => void
+  collapsed: boolean
+  setCollapsed: (value: boolean | ((prev: boolean) => boolean)) => void
+} {
+  const pathname = usePathname()
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [collapsed, setCollapsed] = useState(false)
+
+  return {
+    pathname,
+    sidebarOpen,
+    setSidebarOpen,
+    collapsed,
+    setCollapsed,
+  }
+}


### PR DESCRIPTION
## What
- Adds useAdminShell hook to manage admin layout state
- Provides pathname, sidebar visibility, and collapse state

## Why
Centralizes UI state logic for admin shell (sidebar open/collapse and routing context),
making layout components simpler and more maintainable.

## Files changed
- web/features/admin/admin-shell/hooks/useAdminShell.ts

## How to test
- Use hook inside admin layout
- Toggle sidebar and collapse state
- Verify pathname updates correctly

Closes #226