### PR TITLE
feat(web): add exam grading route page

### DIFF
--- a/web/app/teacher/exams/[id]/grade/page.tsx
+++ b/web/app/teacher/exams/[id]/grade/page.tsx
@@ -1,0 +1,5 @@
+import { ExamGrade } from '@/features/teacher/exam-detail/ExamGrade'
+
+export default function Page({ params }: { params: Promise<{ id: string }> }) {
+  return <ExamGrade params={params} />
+}


### PR DESCRIPTION
## What
Adds grading route for exams.

## Why
Provides dedicated interface for grading workflows.

## Changes
- Created `/teacher/exams/[id]/grade`

## How to test
- Open grading page via route

## Notes
- Will connect to grading workspace

Closes #270