### PR TITLE
feat(web): add grading hub route page

### DIFF
--- a/web/app/teacher/grading/page.tsx
+++ b/web/app/teacher/grading/page.tsx
@@ -1,0 +1,5 @@
+import { GradingHub } from '@/features/teacher/grading-hub/GradingHub'
+
+export default function Page() {
+  return <GradingHub />
+}


### PR DESCRIPTION
## What
Adds grading hub route.

## Why
Centralizes grading activities.

## Changes
- Created `/teacher/grading`

## How to test
- Open grading page

## Notes
- Will integrate grading hub feature

Closes #282