### PR TITLE
feat(api): export parse exam types index

### DIFF
--- a/api/src/shared/types/index.ts
+++ b/api/src/shared/types/index.ts
@@ -5,3 +5,4 @@ export * from './notification.types';
 export * from './monitoring.types';
 export * from './session.types';
 export * from './question.types';
+export * from './parse-exam.types';


### PR DESCRIPTION
## What

Export parse exam related types from the API index.

## Why

To make the exam parsing types easier to import and use across the codebase from a single entry point.

## Changes

- Exported parse exam related types from the API index
- Improved access to shared parser type definitions
- Simplified imports for exam parsing types

## How to test

1. Open the API index file
2. Confirm the parse exam related types are exported
3. Run type checking and verify imports resolve correctly

## Notes

This is a type export change and does not affect runtime behavior.

Closes #571 