### PR TITLE
feat(api): add parse exam html util

### DIFF
--- a/api/src/shared/utils/parse-exam-html.util.ts
+++ b/api/src/shared/utils/parse-exam-html.util.ts
@@ -1,0 +1,26 @@
+export function decodeHtmlEntities(value: string) {
+  return value
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, code) =>
+      String.fromCharCode(parseInt(code, 16)),
+    )
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'");
+}
+
+export function stripHtml(value: string) {
+  return decodeHtmlEntities(value.replace(/<[^>]+>/g, ' '));
+}
+
+export function escapeXml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}


### PR DESCRIPTION
## What

Add a parse exam HTML utility in the API.

## Why

To provide a reusable utility for parsing exam HTML content and support exam import functionality more cleanly.

## Changes

- Added a parse exam HTML utility
- Centralized exam HTML parsing logic
- Improved reuse for exam parsing related flows

## How to test

1. Open the new parse exam HTML utility
2. Verify it handles the expected exam HTML input format
3. Run type checking or related tests to confirm it works correctly

## Notes

This change adds a utility only and does not introduce direct UI changes.

Closes #577 