### PR TITLE
feat(api): export parse exam utils index

### DIFF
--- a/api/src/shared/utils/index.ts
+++ b/api/src/shared/utils/index.ts
@@ -1,1 +1,5 @@
 export * from './exam-session';
+export * from './parse-exam-html.util';
+export * from './parse-exam-question.util';
+export * from './parse-exam-table.util';
+export * from './parse-exam-text.util';


### PR DESCRIPTION
## What

Export parse exam utilities from the API index.

## Why

To make the exam parsing utilities easier to import and use across the codebase from a single entry point.

## Changes

- Exported parse exam utilities from the API index
- Improved access to shared exam parsing utilities
- Simplified imports for exam parsing related modules

## How to test

1. Open the API index file
2. Confirm the parse exam utilities are exported
3. Run type checking and verify imports resolve correctly

## Notes

This is an export-only change and does not affect runtime behavior.

Closes #581 