### PR TITLE
feat(api): add parse exam dto

### DIFF
--- a/api/src/modules/parse-exam/dto/parse-exam.dto.ts
+++ b/api/src/modules/parse-exam/dto/parse-exam.dto.ts
@@ -1,0 +1,27 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class ParseExamDto {
+  @IsOptional()
+  @IsString()
+  fileText?: string;
+
+  @IsOptional()
+  @IsString()
+  fileBuffer?: string;
+
+  @IsOptional()
+  @IsString()
+  fileName?: string;
+
+  @IsOptional()
+  @IsString()
+  fileType?: string;
+
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  courseLabel?: string;
+}


### PR DESCRIPTION
## What

Add a parse exam DTO in the API.

## Why

To define the request and response structure for exam parsing and make the API contract clearer and more consistent.

## Changes

- Added a parse exam DTO
- Defined the data shape used for exam parsing
- Improved consistency for exam parsing related API inputs and outputs

## How to test

1. Open the new parse exam DTO file
2. Confirm the DTO matches the expected exam parsing payload structure
3. Run type checking and verify there are no TypeScript errors

## Notes

This change adds DTO definitions only and does not introduce direct UI changes.

Closes #583 