### PR TITLE
feat(api): add docx parse exam extractor

### DIFF
--- a/api/src/modules/parse-exam/extractors/parse-exam-docx.extractor.ts
+++ b/api/src/modules/parse-exam/extractors/parse-exam-docx.extractor.ts
@@ -1,0 +1,54 @@
+import mammoth from 'mammoth';
+import { decodeHtmlEntities } from '../../../shared/utils/parse-exam-html.util';
+import { convertTableHtmlToImage } from '../../../shared/utils/parse-exam-table.util';
+import {
+  normalizePreservingLines,
+  stripRepeatedPageChrome,
+} from '../../../shared/utils/parse-exam-text.util';
+
+interface MammothHtmlResult {
+  value: string;
+}
+
+function isMammothHtmlResult(value: unknown): value is MammothHtmlResult {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const result = value as Record<string, unknown>;
+
+  return typeof result.value === 'string';
+}
+
+export async function extractDocxContent(buffer: Buffer) {
+  const tableImages: Record<string, string> = {};
+  const htmlResult: unknown = await mammoth.convertToHtml({ buffer });
+  if (!isMammothHtmlResult(htmlResult)) {
+    throw new TypeError('DOCX parser returned an unexpected HTML result.');
+  }
+
+  let tableIndex = 0;
+
+  const htmlWithMarkers = htmlResult.value.replace(
+    /<table[\s\S]*?<\/table>/gi,
+    (tableHtml) => {
+      tableIndex += 1;
+      const marker = `[TABLE_IMAGE_${tableIndex}]`;
+      const imageUrl = convertTableHtmlToImage(tableHtml);
+      if (imageUrl) tableImages[marker] = imageUrl;
+      return `\n${marker}\n`;
+    },
+  );
+
+  const text = decodeHtmlEntities(
+    htmlWithMarkers
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/(p|div|li|tr|h1|h2|h3|h4|h5|h6)>/gi, '\n')
+      .replace(/<[^>]+>/g, ' '),
+  );
+
+  return {
+    text: stripRepeatedPageChrome(normalizePreservingLines(text)),
+    tableImages,
+  };
+}


### PR DESCRIPTION
## What

Add a DOCX parse exam extractor in the API.

## Why

To support extracting exam content from DOCX files and integrate DOCX-based parsing into the exam import flow.

## Changes

- Added a DOCX parse exam extractor
- Implemented DOCX content extraction for exam parsing
- Extended exam import support for DOCX files

## How to test

1. Open the new DOCX parse exam extractor
2. Verify it reads and extracts exam content from a DOCX file correctly
3. Run related tests or type checking to confirm the extractor works as expected

## Notes

This change adds DOCX parsing support in the API and does not introduce direct UI changes.

Closes #584 