### PR TITLE
feat(api): add pdf parse exam extractor

### DIFF
--- a/api/src/modules/parse-exam/extractors/parse-exam-pdf.extractor.ts
+++ b/api/src/modules/parse-exam/extractors/parse-exam-pdf.extractor.ts
@@ -1,0 +1,56 @@
+import { PDFParse } from 'pdf-parse';
+import {
+  normalizePreservingLines,
+  stripRepeatedPageChrome,
+} from '../../../shared/utils/parse-exam-text.util';
+
+interface PdfParserLike {
+  destroy: () => Promise<void>;
+  getText: () => Promise<unknown>;
+}
+
+interface PdfTextResultLike {
+  text?: string;
+}
+
+function isPdfParserLike(value: unknown): value is PdfParserLike {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const parser = value as Record<string, unknown>;
+
+  return (
+    typeof parser.destroy === 'function' && typeof parser.getText === 'function'
+  );
+}
+
+function isPdfTextResultLike(value: unknown): value is PdfTextResultLike {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const result = value as Record<string, unknown>;
+
+  return result.text === undefined || typeof result.text === 'string';
+}
+
+export async function extractPdfContent(buffer: Buffer) {
+  const parser: unknown = new PDFParse({ data: buffer });
+  if (!isPdfParserLike(parser)) {
+    throw new TypeError('PDF parser returned an unexpected parser instance.');
+  }
+
+  try {
+    const extracted: unknown = await parser.getText();
+    if (!isPdfTextResultLike(extracted)) {
+      throw new TypeError('PDF parser returned an unexpected text result.');
+    }
+
+    return stripRepeatedPageChrome(
+      normalizePreservingLines(extracted.text ?? ''),
+    );
+  } finally {
+    await parser.destroy();
+  }
+}


### PR DESCRIPTION
## What

Add a PDF parse exam extractor in the API.

## Why

To support extracting exam content from PDF files and integrate PDF-based parsing into the exam import flow.

## Changes

- Added a PDF parse exam extractor
- Implemented PDF content extraction for exam parsing
- Extended exam import support for PDF files

## How to test

1. Open the new PDF parse exam extractor
2. Verify it reads and extracts exam content from a PDF file correctly
3. Run related tests or type checking to confirm the extractor works as expected

## Notes

This change adds PDF parsing support in the API and does not introduce direct UI changes.

Closes #585 