### PR TITLE
feat(api): add parse exam module

### DIFF
--- a/api/src/modules/parse-exam/parse-exam.module.ts
+++ b/api/src/modules/parse-exam/parse-exam.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ParseExamController } from './parse-exam.controller';
+import { ParseExamRepository } from './parse-exam.repository';
+import { ParseExamService } from './parse-exam.service';
+
+@Module({
+  controllers: [ParseExamController],
+  providers: [ParseExamRepository, ParseExamService],
+  exports: [ParseExamService, ParseExamRepository],
+})
+export class ParseExamModule {}


### PR DESCRIPTION
## What

Add a parse exam module in the API.

## Why

To organize the exam parsing feature into a dedicated module and make the related controller, services, and utilities easier to manage.

## Changes

- Added a parse exam module
- Grouped exam parsing logic under a dedicated API module
- Improved structure for exam parsing related components

## How to test

1. Open the new parse exam module
2. Verify the related exam parsing components are registered correctly
3. Run the API and confirm the exam parsing feature is wired properly

## Notes

This change organizes the exam parsing feature and does not introduce direct UI changes.

Closes #587 