### PR TITLE
feat(api): add parse exam service

### DIFF
--- a/api/src/modules/parse-exam/parse-exam.service.ts
+++ b/api/src/modules/parse-exam/parse-exam.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { ParseExamDto } from './dto/parse-exam.dto';
+import { ParseExamRepository } from './parse-exam.repository';
+
+@Injectable()
+export class ParseExamService {
+  constructor(private readonly parseExamRepository: ParseExamRepository) {}
+
+  parseExam(body: ParseExamDto) {
+    return this.parseExamRepository.parseExam(body);
+  }
+}


### PR DESCRIPTION
## What

Add a parse exam service in the API.

## Why

To centralize the core exam parsing logic and provide a reusable service for handling exam parsing workflows.

## Changes

- Added a parse exam service
- Moved exam parsing logic into a dedicated service layer
- Improved structure and reuse for exam parsing related functionality

## How to test

1. Open the new parse exam service
2. Verify the service handles the expected exam parsing flow
3. Run related tests or the API flow and confirm the service works as expected

## Notes

This change adds a service layer for exam parsing and does not introduce direct UI changes.

Closes #589 