### PR TITLE
feat(api): add parse exam controller

### DIFF
--- a/api/src/modules/parse-exam/parse-exam.controller.ts
+++ b/api/src/modules/parse-exam/parse-exam.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ParseExamDto } from './dto/parse-exam.dto';
+import { ParseExamService } from './parse-exam.service';
+
+@Controller('parse-exam')
+export class ParseExamController {
+  constructor(private readonly parseExamService: ParseExamService) {}
+
+  @Post()
+  parseExam(@Body() body: ParseExamDto) {
+    return this.parseExamService.parseExam(body);
+  }
+}


### PR DESCRIPTION
## What

Add a parse exam controller in the API.

## Why

To expose an endpoint for exam parsing and connect the parsing flow to the API layer.

## Changes

- Added a parse exam controller
- Exposed an API endpoint for exam parsing
- Connected exam parsing requests to the underlying parsing logic

## How to test

1. Open the new parse exam controller
2. Verify the exam parsing endpoint is defined correctly
3. Send a request to the endpoint and confirm it returns the expected result

## Notes

This change adds API controller support for exam parsing and does not introduce direct UI changes.

Closes #560 