### PR TITLE
feat(api): add parse exam picture dto

### DIFF
--- a/api/src/modules/parse-exam-picture/dto/parse-exam-picture.dto.ts
+++ b/api/src/modules/parse-exam-picture/dto/parse-exam-picture.dto.ts
@@ -1,0 +1,27 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class ParseExamPictureDto {
+  @IsOptional()
+  @IsString()
+  ocrText?: string;
+
+  @IsOptional()
+  @IsString()
+  fileText?: string;
+
+  @IsOptional()
+  @IsString()
+  fileName?: string;
+
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  courseLabel?: string;
+
+  @IsOptional()
+  @IsString()
+  imageUrl?: string;
+}


### PR DESCRIPTION
## What

Add a parse exam picture DTO in the API.

## Why

To define the data structure for exam picture parsing and make the API contract clearer and more consistent.

## Changes

- Added a parse exam picture DTO
- Defined the payload shape used for exam picture parsing
- Improved consistency for exam parsing related API inputs and outputs

## How to test

1. Open the new parse exam picture DTO file
2. Confirm the DTO matches the expected picture parsing payload structure
3. Run type checking and verify there are no TypeScript errors

## Notes

This change adds DTO definitions only and does not introduce direct UI changes.

Closes #591 