### PR TITLE
feat(api): add parse exam picture controller

### DIFF
--- a/api/src/modules/parse-exam-picture/parse-exam-picture.controller.ts
+++ b/api/src/modules/parse-exam-picture/parse-exam-picture.controller.ts
@@ -1,0 +1,15 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ParseExamPictureDto } from './dto/parse-exam-picture.dto';
+import { ParseExamPictureService } from './parse-exam-picture.service';
+
+@Controller('parse-exam-picture')
+export class ParseExamPictureController {
+  constructor(
+    private readonly parseExamPictureService: ParseExamPictureService,
+  ) {}
+
+  @Post()
+  parseExamPicture(@Body() body: ParseExamPictureDto) {
+    return this.parseExamPictureService.parseExamPicture(body);
+  }
+}


### PR DESCRIPTION
## What

Add a parse exam picture controller in the API.

## Why

To expose an endpoint for exam picture parsing and connect the picture parsing flow to the API layer.

## Changes

- Added a parse exam picture controller
- Exposed an API endpoint for exam picture parsing
- Connected exam picture parsing requests to the underlying parsing logic

## How to test

1. Open the new parse exam picture controller
2. Verify the exam picture parsing endpoint is defined correctly
3. Send a request to the endpoint and confirm it returns the expected result

## Notes

This change adds API controller support for exam picture parsing and does not introduce direct UI changes.

Closes #592 