### PR TITLE
feat(api): add parse exam picture module

### DIFF
--- a/api/src/modules/parse-exam-picture/parse-exam-picture.module.ts
+++ b/api/src/modules/parse-exam-picture/parse-exam-picture.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ParseExamModule } from '../parse-exam/parse-exam.module';
+import { ParseExamPictureController } from './parse-exam-picture.controller';
+import { ParseExamPictureService } from './parse-exam-picture.service';
+
+@Module({
+  imports: [ParseExamModule],
+  controllers: [ParseExamPictureController],
+  providers: [ParseExamPictureService],
+})
+export class ParseExamPictureModule {}


### PR DESCRIPTION
## What

Add a parse exam picture module in the API.

## Why

To organize the exam picture parsing feature into a dedicated module and make the related controller, services, and utilities easier to manage.

## Changes

- Added a parse exam picture module
- Grouped exam picture parsing logic under a dedicated API module
- Improved structure for exam picture parsing related components

## How to test

1. Open the new parse exam picture module
2. Verify the related exam picture parsing components are registered correctly
3. Run the API and confirm the exam picture parsing feature is wired properly

## Notes

This change organizes the exam picture parsing feature and does not introduce direct UI changes.

Closes #[issue-number]
