### PR TITLE
feat(api): add parse exam picture service

### DIFF
--- a/api/src/modules/parse-exam-picture/parse-exam-picture.service.ts
+++ b/api/src/modules/parse-exam-picture/parse-exam-picture.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { ParseExamRepository } from '../parse-exam/parse-exam.repository';
+import { ParseExamPictureDto } from './dto/parse-exam-picture.dto';
+
+@Injectable()
+export class ParseExamPictureService {
+  constructor(private readonly parseExamRepository: ParseExamRepository) {}
+
+  parseExamPicture(body: ParseExamPictureDto) {
+    return this.parseExamRepository.parseExamPicture(body);
+  }
+}


### PR DESCRIPTION
## What

Add a parse exam picture service in the API.

## Why

To centralize the core exam picture parsing logic and provide a reusable service for handling picture-based exam parsing workflows.

## Changes

- Added a parse exam picture service
- Moved exam picture parsing logic into a dedicated service layer
- Improved structure and reuse for exam picture parsing related functionality

## How to test

1. Open the new parse exam picture service
2. Verify the service handles the expected exam picture parsing flow
3. Run related tests or the API flow and confirm the service works as expected

## Notes

This change adds a service layer for exam picture parsing and does not introduce direct UI changes.

Closes #594 