### PR TITLE
feat(api): add dto for fetching offline exam drafts

### DIFF
--- a/api/src/modules/offline-exam-sync/dto/get-offline-draft.dto.ts
+++ b/api/src/modules/offline-exam-sync/dto/get-offline-draft.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class GetOfflineDraftDto {
+  @IsString()
+  @IsNotEmpty()
+  assignmentId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  studentId: string;
+}


### PR DESCRIPTION
## What

Add a DTO for fetching offline exam drafts.

## Why

To define the request shape for fetching offline exam drafts and keep the API contract clear and consistent.

## Changes

- Added a DTO for fetching offline exam drafts
- Defined the payload structure used by the fetch draft flow
- Improved consistency for offline exam draft related API inputs

## How to test

1. Open the new DTO file
2. Confirm the DTO matches the expected fetch offline exam draft payload
3. Run type checking and verify there are no TypeScript errors

## Notes

This change adds DTO definitions only and does not introduce direct UI changes.

Closes #623 