### PR TITLE
feat(api): add dto for listing offline exam submissions

### DIFF
--- a/api/src/modules/offline-exam-sync/dto/list-offline-submission.dto.ts
+++ b/api/src/modules/offline-exam-sync/dto/list-offline-submission.dto.ts
@@ -1,0 +1,19 @@
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ListOfflineSubmissionDto {
+  @IsOptional()
+  @IsString()
+  studentId?: string;
+
+  @IsOptional()
+  @IsString()
+  assignmentId?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(1000)
+  limit?: number = 500;
+}


### PR DESCRIPTION
## What

Add a DTO for listing offline exam submissions.

## Why

To define the request shape for listing offline exam submissions and keep the API contract clear and consistent.

## Changes

- Added a DTO for listing offline exam submissions
- Defined the payload structure used by the submission listing flow
- Improved consistency for offline exam submission related API inputs

## How to test

1. Open the new DTO file
2. Confirm the DTO matches the expected list offline exam submissions payload
3. Run type checking and verify there are no TypeScript errors

## Notes

This change adds DTO definitions only and does not introduce direct UI changes.

Closes #625 