### PR TITLE
feat(api): add dto for saving offline exam drafts

### DIFF
--- a/api/src/modules/offline-exam-sync/dto/upsert-offline-draft.dto.ts
+++ b/api/src/modules/offline-exam-sync/dto/upsert-offline-draft.dto.ts
@@ -1,0 +1,43 @@
+import {
+  IsArray,
+  IsDateString,
+  IsInt,
+  IsNotEmpty,
+  IsObject,
+  IsString,
+  Min,
+} from 'class-validator';
+
+export class UpsertOfflineDraftDto {
+  @IsString()
+  @IsNotEmpty()
+  draftKey: string;
+
+  @IsString()
+  @IsNotEmpty()
+  assignmentId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  examId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  studentId: string;
+
+  @IsObject()
+  answers: Record<string, string | string[]>;
+
+  @IsArray()
+  markedForReview: string[];
+
+  @IsInt()
+  @Min(0)
+  currentIndex: number;
+
+  @IsDateString()
+  startedAt: string;
+
+  @IsDateString()
+  updatedAt: string;
+}


### PR DESCRIPTION
## What

Add a DTO for saving offline exam drafts.

## Why

To define the request shape for saving offline exam drafts and keep the API contract clear and consistent.

## Changes

- Added a DTO for saving offline exam drafts
- Defined the payload structure used by the save draft flow
- Improved consistency for offline exam draft related API inputs

## How to test

1. Open the new DTO file
2. Confirm the DTO matches the expected save offline exam draft payload
3. Run type checking and verify there are no TypeScript errors

## Notes

This change adds DTO definitions only and does not introduce direct UI changes.

Closes #626 