### PR TITLE
feat(api): add dto for saving offline exam submissions

### DIFF
--- a/api/src/modules/offline-exam-sync/dto/upsert-offline-submission.dto.ts
+++ b/api/src/modules/offline-exam-sync/dto/upsert-offline-submission.dto.ts
@@ -1,0 +1,31 @@
+import {
+  IsDateString,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+export class UpsertOfflineSubmissionDto {
+  @IsString()
+  @IsNotEmpty()
+  assignmentId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  examId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  studentId: string;
+
+  @IsObject()
+  attempt: Record<string, unknown>;
+
+  @IsObject()
+  result: Record<string, unknown>;
+
+  @IsOptional()
+  @IsDateString()
+  queuedAt?: string;
+}


### PR DESCRIPTION
## What

Add a DTO for saving offline exam submissions.

## Why

To define the request shape for saving offline exam submissions and keep the API contract clear and consistent.

## Changes

- Added a DTO for saving offline exam submissions
- Defined the payload structure used by the submission save flow
- Improved consistency for offline exam submission related API inputs

## How to test

1. Open the new DTO file
2. Confirm the DTO matches the expected save offline exam submission payload
3. Run type checking and verify there are no TypeScript errors

## Notes

This change adds DTO definitions only and does not introduce direct UI changes.

Closes #627 