### PR TITLE
feat(api): add offline exam sync repository

### DIFF
--- a/api/src/modules/offline-exam-sync/offline-exam-sync.repository.ts
+++ b/api/src/modules/offline-exam-sync/offline-exam-sync.repository.ts
@@ -1,0 +1,160 @@
+import { Injectable } from '@nestjs/common';
+import { and, desc, eq } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+import { db } from 'src/database/client';
+import {
+  offlineExamDrafts,
+  offlineExamSubmissions,
+} from '../../database/schema/offline-exam-sync.schema';
+
+@Injectable()
+export class OfflineExamSyncRepository {
+  async findDraft(assignmentId: string, studentId: string) {
+    const [draft] = await db
+      .select()
+      .from(offlineExamDrafts)
+      .where(
+        and(
+          eq(offlineExamDrafts.assignmentId, assignmentId),
+          eq(offlineExamDrafts.studentId, studentId),
+        ),
+      )
+      .limit(1);
+
+    return draft ?? null;
+  }
+
+  async upsertDraft(payload: {
+    draftKey: string;
+    assignmentId: string;
+    examId: string;
+    studentId: string;
+    answersJson: string;
+    markedForReviewJson: string;
+    currentIndex: number;
+    startedAt: Date;
+    clientUpdatedAt: Date;
+  }) {
+    const [draft] = await db
+      .insert(offlineExamDrafts)
+      .values({
+        id: randomUUID(),
+        draftKey: payload.draftKey,
+        assignmentId: payload.assignmentId,
+        examId: payload.examId,
+        studentId: payload.studentId,
+        answersJson: payload.answersJson,
+        markedForReviewJson: payload.markedForReviewJson,
+        currentIndex: payload.currentIndex,
+        startedAt: payload.startedAt,
+        clientUpdatedAt: payload.clientUpdatedAt,
+        syncedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [offlineExamDrafts.assignmentId, offlineExamDrafts.studentId],
+        set: {
+          draftKey: payload.draftKey,
+          examId: payload.examId,
+          answersJson: payload.answersJson,
+          markedForReviewJson: payload.markedForReviewJson,
+          currentIndex: payload.currentIndex,
+          startedAt: payload.startedAt,
+          clientUpdatedAt: payload.clientUpdatedAt,
+          syncedAt: new Date(),
+        },
+      })
+      .returning();
+
+    return draft;
+  }
+
+  async deleteDraft(assignmentId: string, studentId: string) {
+    await db
+      .delete(offlineExamDrafts)
+      .where(
+        and(
+          eq(offlineExamDrafts.assignmentId, assignmentId),
+          eq(offlineExamDrafts.studentId, studentId),
+        ),
+      );
+  }
+
+  async listSubmissions(params: {
+    studentId?: string;
+    assignmentId?: string;
+    limit: number;
+  }) {
+    const query = db
+      .select()
+      .from(offlineExamSubmissions)
+      .orderBy(desc(offlineExamSubmissions.submittedAt))
+      .limit(params.limit);
+
+    if (params.studentId && params.assignmentId) {
+      return query.where(
+        and(
+          eq(offlineExamSubmissions.studentId, params.studentId),
+          eq(offlineExamSubmissions.assignmentId, params.assignmentId),
+        ),
+      );
+    }
+
+    if (params.studentId) {
+      return query.where(
+        eq(offlineExamSubmissions.studentId, params.studentId),
+      );
+    }
+
+    if (params.assignmentId) {
+      return query.where(
+        eq(offlineExamSubmissions.assignmentId, params.assignmentId),
+      );
+    }
+
+    return query;
+  }
+
+  async upsertSubmission(payload: {
+    assignmentId: string;
+    examId: string;
+    studentId: string;
+    attemptId: string;
+    resultId: string;
+    attemptJson: string;
+    resultJson: string;
+    submittedAt: Date;
+  }) {
+    const [submission] = await db
+      .insert(offlineExamSubmissions)
+      .values({
+        id: randomUUID(),
+        assignmentId: payload.assignmentId,
+        examId: payload.examId,
+        studentId: payload.studentId,
+        attemptId: payload.attemptId,
+        resultId: payload.resultId,
+        attemptJson: payload.attemptJson,
+        resultJson: payload.resultJson,
+        submittedAt: payload.submittedAt,
+        syncedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [
+          offlineExamSubmissions.assignmentId,
+          offlineExamSubmissions.studentId,
+        ],
+        set: {
+          examId: payload.examId,
+          attemptId: payload.attemptId,
+          resultId: payload.resultId,
+          attemptJson: payload.attemptJson,
+          resultJson: payload.resultJson,
+          submittedAt: payload.submittedAt,
+          syncedAt: new Date(),
+        },
+      })
+      .returning();
+
+    return submission;
+  }
+}


### PR DESCRIPTION
## What

Add an offline exam sync repository in the API.

## Why

To provide a dedicated data access layer for offline exam sync and keep draft and submission persistence logic organized and maintainable.

## Changes

- Added an offline exam sync repository
- Separated offline exam sync data access logic into a dedicated layer
- Improved structure for offline exam sync related persistence operations

## How to test

1. Open the new offline exam sync repository
2. Verify the repository methods are defined correctly
3. Run related tests or the API flow and confirm repository interactions work as expected

## Notes

This change adds a repository layer for offline exam sync and does not introduce direct UI changes.

Closes #630 