### PR TITLE
feat(api): serve uploaded answer assets and increase request size limits

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -2,15 +2,26 @@ import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app/app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import express from 'express';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  const uploadsRoot = join(process.cwd(), 'uploads');
+  const answerUploadsRoot = join(uploadsRoot, 'answers');
+
+  if (!existsSync(answerUploadsRoot)) {
+    mkdirSync(answerUploadsRoot, { recursive: true });
+  }
 
   app.enableCors({
     origin: true,
     credentials: true,
   });
 
+  app.use(express.json({ limit: '25mb' }));
+  app.use(express.urlencoded({ extended: true, limit: '25mb' }));
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
@@ -18,6 +29,8 @@ async function bootstrap() {
       transform: true,
     }),
   );
+
+  app.use('/uploads', express.static(uploadsRoot));
 
   await app.listen(process.env.PORT ?? 3000, '0.0.0.0');
 }


### PR DESCRIPTION
## What

Serve uploaded answer assets and increase request size limits in the API.

## Why

To support larger answer upload payloads and ensure uploaded answer assets can be accessed correctly by the application.

## Changes

- Added support for serving uploaded answer assets
- Increased request size limits for larger upload payloads
- Improved API handling for answer asset upload flows

## How to test

1. Upload an answer asset through the API flow
2. Verify the uploaded asset can be accessed successfully
3. Send a larger request payload and confirm it is accepted without size limit errors

## Notes

This change updates API upload handling and asset serving behavior and does not introduce direct UI changes.

Closes #694 