### PR TITLE
feat(api): add answer asset upload endpoint for student submissions

### DIFF
--- a/api/src/modules/answer/answer.controller.ts
+++ b/api/src/modules/answer/answer.controller.ts
@@ -2,10 +2,14 @@ import {
   Body,
   Controller,
   Get,
+  HttpCode,
   Param,
   Patch,
   Post,
+  Req,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import { AnswerService } from './answer.service';
 import { UpsertAnswerDto } from './dto/upsert-answer.dto';
@@ -14,6 +18,18 @@ import { RolesGuard } from 'src/modules/auth/guards/roles.guard';
 import { Roles } from 'src/modules/auth/decorators/roles.decorator';
 import { CurrentUser } from 'src/modules/auth/decorators/current-user.decorator';
 import type { AuthenticatedUser } from 'src/modules/auth/interfaces/authenticated-user.interface';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { diskStorage } from 'multer';
+import { extname } from 'node:path';
+import { UploadAnswerAssetDto } from './dto/upload-answer-asset.dto';
+import type { Request } from 'express';
+
+type UploadedAnswerFile = {
+  filename: string;
+  originalname: string;
+  mimetype: string;
+  size: number;
+};
 
 @Controller('answers')
 @UseGuards(ClerkAuthGuard, RolesGuard)
@@ -36,6 +52,32 @@ export class AnswerController {
     @CurrentUser() user: AuthenticatedUser,
   ) {
     return this.answerService.autosaveAnswer(body, user);
+  }
+
+  @Post('upload')
+  @HttpCode(201)
+  @Roles('student')
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: diskStorage({
+        destination: 'uploads/answers',
+        filename: (_req, file, cb) => {
+          const safeExtension = extname(file.originalname) || '.bin';
+          cb(null, `${Date.now()}-${crypto.randomUUID()}${safeExtension}`);
+        },
+      }),
+      limits: {
+        fileSize: 25 * 1024 * 1024,
+      },
+    }),
+  )
+  uploadAnswerAsset(
+    @UploadedFile() file: UploadedAnswerFile,
+    @Body() body: UploadAnswerAssetDto,
+    @CurrentUser() user: AuthenticatedUser,
+    @Req() request: Request,
+  ) {
+    return this.answerService.uploadAnswerAsset(file, body, user, request);
   }
 
   @Patch('session/:sessionId/finalize')


### PR DESCRIPTION
## What

Add an answer asset upload endpoint for student submissions in the API.

## Why

To support uploading files or assets as part of student submission flows and provide a dedicated API endpoint for handling those uploads.

## Changes

- Added an answer asset upload endpoint for student submissions
- Enabled asset upload support in the student submission flow
- Improved API handling for submission related file uploads

## How to test

1. Send a student submission asset upload request to the new endpoint
2. Verify the upload completes successfully and returns the expected response
3. Confirm the uploaded asset is available for the related submission flow

## Notes

This change adds upload support for student submission assets in the API and does not introduce direct UI changes.

Closes #695 