### PR TITLE
feat(api): return public asset urls for uploaded answer files

### DIFF
--- a/api/src/modules/answer/answer.service.ts
+++ b/api/src/modules/answer/answer.service.ts
@@ -12,6 +12,15 @@ import { QuestionRepository } from '../question/question.repository';
 import { ExamRepository } from '../exam/exam.repository';
 import { SessionService } from '../session/session.service';
 import { getSessionTiming } from 'src/shared/utils/exam-session';
+import { UploadAnswerAssetDto } from './dto/upload-answer-asset.dto';
+import type { Request } from 'express';
+
+type UploadedAnswerFile = {
+  filename: string;
+  originalname: string;
+  mimetype: string;
+  size: number;
+};
 
 @Injectable()
 export class AnswerService {
@@ -70,6 +79,40 @@ export class AnswerService {
   async finalizeAnswers(sessionId: string, user: AuthenticatedUser) {
     await this.ensureSessionAccess(sessionId, user, true);
     return this.answerRepo.finalizeAnswers(sessionId);
+  }
+
+  uploadAnswerAsset(
+    file: UploadedAnswerFile | undefined,
+    body: UploadAnswerAssetDto,
+    user: AuthenticatedUser,
+    request: Request,
+  ) {
+    if (user.role !== 'student') {
+      throw new ForbiddenException('Only students can upload answer files');
+    }
+
+    if (!file) {
+      throw new BadRequestException('File is required');
+    }
+
+    const forwardedProto =
+      (request.headers['x-forwarded-proto'] as string | undefined)?.split(',')[0] ??
+      request.protocol;
+    const forwardedHost =
+      (request.headers['x-forwarded-host'] as string | undefined)?.split(',')[0] ??
+      request.get('host');
+
+    if (!forwardedHost) {
+      throw new BadRequestException('Host header is missing');
+    }
+
+    return {
+      url: `${forwardedProto}://${forwardedHost}/uploads/answers/${file.filename}`,
+      fileName: file.originalname,
+      mimeType: file.mimetype,
+      size: file.size,
+      kind: body.kind ?? null,
+    };
   }
 
   private async ensureSessionAccess(


### PR DESCRIPTION
## What

Return public asset URLs for uploaded answer files in the API.

## Why

To make uploaded answer files directly accessible after upload and simplify how clients consume submitted asset references.

## Changes

- Returned public asset URLs for uploaded answer files
- Updated the upload response to include accessible file URLs
- Improved client integration for answer file handling

## How to test

1. Upload an answer file through the API
2. Verify the response includes a public asset URL
3. Open the returned URL and confirm the uploaded file is accessible

## Notes

This change updates the upload response format for answer files and does not introduce direct UI changes.

Closes #696 