### PR TITLE
feat(api): add enrollment lookup by exam and student for office sync

### DIFF
--- a/api/src/modules/enrollment/enrollment.repository.ts
+++ b/api/src/modules/enrollment/enrollment.repository.ts
@@ -31,6 +31,18 @@ export class EnrollmentRepository {
     });
   }
 
+  async findEnrollmentByExamAndStudent(
+    examId: string,
+    studentId: string,
+  ): Promise<Enrollment | undefined> {
+    return db.query.examEnrollments.findFirst({
+      where: and(
+        eq(examEnrollments.examId, examId),
+        eq(examEnrollments.studentId, studentId),
+      ),
+    });
+  }
+
   async removeEnrollment(examId: string, studentId: string) {
     await db
       .delete(examEnrollments)


### PR DESCRIPTION
## What

Add enrollment lookup by exam and student for office sync in the API.

## Why

To support office sync flows that need to resolve a specific enrollment record using both exam and student identifiers.

## Changes

- Added enrollment lookup by exam and student
- Supported office sync flows with targeted enrollment retrieval
- Improved API support for exam-student enrollment matching

## How to test

1. Send a request or trigger the office sync flow with exam and student identifiers
2. Verify the correct enrollment record is returned
3. Confirm the lookup works as expected in the related office sync path

## Notes

This change adds enrollment lookup support for office sync and does not introduce direct UI changes.

Closes #698 