### PR TITLE
refactor(api): reconcile offline exam drafts and submissions into liv…

### DIFF
--- a/api/src/modules/offline-exam-sync/offline-exam-sync.service.ts
+++ b/api/src/modules/offline-exam-sync/offline-exam-sync.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Injectable,
   InternalServerErrorException,
+  NotFoundException,
 } from '@nestjs/common';
 import type { InferSelectModel } from 'drizzle-orm';
 import {
@@ -11,6 +12,12 @@ import {
 import { OfflineExamSyncRepository } from './offline-exam-sync.repository';
 import { UpsertOfflineDraftDto } from './dto/upsert-offline-draft.dto';
 import { UpsertOfflineSubmissionDto } from './dto/upsert-offline-submission.dto';
+import { SessionRepository } from '../session/session.repository';
+import { AnswerRepository } from '../answer/answer.repository';
+import { ExamRepository } from '../exam/exam.repository';
+import { QuestionRepository } from '../question/question.repository';
+import { EnrollmentRepository } from '../enrollment/enrollment.repository';
+import { getSessionTiming } from 'src/shared/utils/exam-session';
 
 type OfflineExamDraftRecord = InferSelectModel<typeof offlineExamDrafts>;
 type OfflineExamSubmissionRecord = InferSelectModel<
@@ -35,15 +42,25 @@ type ResultPayload = OfflineSubmissionPayload & {
 type OfflineDraftResponse = OfflineExamDraftRecord & {
   answers: OfflineDraftAnswers;
   markedForReview: string[];
+  reconciledSessionId?: string | null;
 };
 type OfflineSubmissionResponse = OfflineExamSubmissionRecord & {
   attempt: OfflineSubmissionPayload;
   result: OfflineSubmissionPayload;
+  reconciledSessionId?: string | null;
+  reconciledAt?: string | null;
 };
 
 @Injectable()
 export class OfflineExamSyncService {
-  constructor(private readonly repository: OfflineExamSyncRepository) {}
+  constructor(
+    private readonly repository: OfflineExamSyncRepository,
+    private readonly sessionRepo: SessionRepository,
+    private readonly answerRepo: AnswerRepository,
+    private readonly examRepo: ExamRepository,
+    private readonly questionRepo: QuestionRepository,
+    private readonly enrollmentRepo: EnrollmentRepository,
+  ) {}
 
   async getDraft(
     assignmentId: string,
@@ -62,6 +79,11 @@ export class OfflineExamSyncService {
   }
 
   async saveDraft(dto: UpsertOfflineDraftDto): Promise<OfflineDraftResponse> {
+    const { questions } = await this.ensureOfflineExamAccess(
+      dto.examId,
+      dto.studentId,
+    );
+
     const draft = (await this.repository.upsertDraft({
       draftKey: dto.draftKey,
       assignmentId: dto.assignmentId,
@@ -74,7 +96,30 @@ export class OfflineExamSyncService {
       clientUpdatedAt: new Date(dto.updatedAt),
     })) as OfflineExamDraftRecord;
 
-    return this.mapDraft(draft);
+    const startedAt =
+      this.normalizeIsoDate(dto.startedAt) ?? new Date().toISOString();
+    const updatedAt =
+      this.normalizeIsoDate(dto.updatedAt) ?? new Date().toISOString();
+    const session = await this.sessionRepo.saveOfflineSession({
+      id: `${dto.assignmentId}:${dto.studentId}`,
+      examId: dto.examId,
+      studentId: dto.studentId,
+      status: 'in_progress',
+      startedAt,
+      submittedAt: null,
+      createdAt: startedAt,
+      updatedAt,
+    });
+
+    await this.persistOfflineAnswers(
+      session.id,
+      questions,
+      dto.answers,
+      false,
+      updatedAt,
+    );
+
+    return this.mapDraft(draft, session.id);
   }
 
   async deleteDraft(assignmentId: string, studentId: string) {
@@ -98,8 +143,46 @@ export class OfflineExamSyncService {
   ): Promise<OfflineSubmissionResponse> {
     const attempt = this.validateAttemptPayload(dto.attempt);
     const result = this.validateResultPayload(dto.result);
+    const { exam, questions } = await this.ensureOfflineExamAccess(
+      dto.examId,
+      dto.studentId,
+    );
 
     this.ensureSubmissionConsistency(dto, attempt, result);
+
+    const startedAt =
+      this.getOptionalString(dto.attempt, 'startedAt', 'attempt') ??
+      new Date().toISOString();
+    const submittedAt = this.resolveSubmittedAt(result, attempt, dto.queuedAt);
+    const session = await this.sessionRepo.saveOfflineSession({
+      id: attempt.id,
+      examId: dto.examId,
+      studentId: dto.studentId,
+      status: 'in_progress',
+      startedAt,
+      submittedAt: null,
+      createdAt: startedAt,
+      updatedAt: submittedAt.toISOString(),
+    });
+
+    await this.persistOfflineAnswers(
+      session.id,
+      questions,
+      this.extractAttemptAnswers(dto.attempt),
+      true,
+      submittedAt.toISOString(),
+    );
+
+    const timing = getSessionTiming(
+      exam,
+      { startedAt: session.startedAt },
+      submittedAt,
+    );
+    const submittedSession = await this.sessionRepo.submitSessionAt(
+      session.id,
+      submittedAt.toISOString(),
+      timing.isExpired ? 'force_submitted' : 'submitted',
+    );
 
     const submission = (await this.repository.upsertSubmission({
       assignmentId: dto.assignmentId,
@@ -109,28 +192,204 @@ export class OfflineExamSyncService {
       resultId: result.id,
       attemptJson: JSON.stringify(dto.attempt),
       resultJson: JSON.stringify(dto.result),
-      submittedAt: this.resolveSubmittedAt(result, attempt, dto.queuedAt),
+      submittedAt,
     })) as OfflineExamSubmissionRecord;
 
-    return this.mapSubmission(submission);
+    await this.repository.deleteDraft(dto.assignmentId, dto.studentId);
+
+    return this.mapSubmission(
+      submission,
+      submittedSession.id,
+      submittedSession.updatedAt,
+    );
   }
 
-  private mapDraft(draft: OfflineExamDraftRecord): OfflineDraftResponse {
+  private mapDraft(
+    draft: OfflineExamDraftRecord,
+    reconciledSessionId: string | null = null,
+  ): OfflineDraftResponse {
     return {
       ...draft,
       answers: this.parseAnswers(draft.answersJson),
       markedForReview: this.parseMarkedForReview(draft.markedForReviewJson),
+      reconciledSessionId,
     };
   }
 
   private mapSubmission(
     submission: OfflineExamSubmissionRecord,
+    reconciledSessionId: string | null = null,
+    reconciledAt: string | null = null,
   ): OfflineSubmissionResponse {
     return {
       ...submission,
       attempt: this.parseObjectPayload(submission.attemptJson, 'attempt'),
       result: this.parseObjectPayload(submission.resultJson, 'result'),
+      reconciledSessionId,
+      reconciledAt,
     };
+  }
+
+  private async ensureOfflineExamAccess(examId: string, studentId: string) {
+    const [exam, enrollment, questions] = await Promise.all([
+      this.examRepo.findExamById(examId),
+      this.enrollmentRepo.findEnrollmentByExamAndStudent(examId, studentId),
+      this.questionRepo.findQuestionsByExam(examId),
+    ]);
+
+    if (!exam) {
+      throw new NotFoundException('Exam not found');
+    }
+
+    if (!enrollment) {
+      throw new BadRequestException('Student is not enrolled for this exam');
+    }
+
+    return { exam, questions };
+  }
+
+  private async persistOfflineAnswers(
+    sessionId: string,
+    questions: Array<{ id: string; inputType: string }>,
+    answerMap: Record<string, string | string[]>,
+    isFinal: boolean,
+    timestamp: string,
+  ) {
+    const questionMap = new Map(questions.map((question) => [question.id, question]));
+
+    await Promise.all(
+      Object.entries(answerMap).map(async ([questionId, rawValue]) => {
+        const question = questionMap.get(questionId);
+
+        if (!question) {
+          throw new BadRequestException(
+            `Question ${questionId} does not belong to this exam`,
+          );
+        }
+
+        const payload = this.mapAnswerPayload(rawValue, question.inputType);
+
+        if (
+          !payload.textAnswer &&
+          !payload.formulaAnswerJson &&
+          !payload.fileUrl
+        ) {
+          return;
+        }
+
+        await this.answerRepo.upsertAnswer({
+          id: crypto.randomUUID(),
+          sessionId,
+          questionId,
+          textAnswer: payload.textAnswer,
+          formulaAnswerJson: payload.formulaAnswerJson,
+          fileUrl: payload.fileUrl,
+          lastSavedAt: timestamp,
+          isFinal,
+          createdAt: timestamp,
+        });
+      }),
+    );
+
+    if (isFinal) {
+      await this.answerRepo.finalizeAnswers(sessionId);
+    }
+  }
+
+  private extractAttemptAnswers(
+    payload: Record<string, unknown>,
+  ): Record<string, string | string[]> {
+    const directAnswers = payload.answers;
+
+    if (this.isRecord(directAnswers)) {
+      return directAnswers as Record<string, string | string[]>;
+    }
+
+    const responses = payload.responses;
+
+    if (Array.isArray(responses)) {
+      return responses.reduce<Record<string, string>>((result, item) => {
+        if (
+          this.isRecord(item) &&
+          typeof item.questionId === 'string' &&
+          typeof item.answer === 'string'
+        ) {
+          result[item.questionId] = item.answer;
+        }
+
+        return result;
+      }, {});
+    }
+
+    throw new BadRequestException('Attempt payload does not contain answers');
+  }
+
+  private mapAnswerPayload(
+    rawValue: string | string[],
+    inputType: string,
+  ) {
+    if (Array.isArray(rawValue)) {
+      return {
+        textAnswer: JSON.stringify(rawValue),
+        formulaAnswerJson: null,
+        fileUrl: null,
+      };
+    }
+
+    const value = rawValue.trim();
+
+    if (value.length === 0) {
+      return {
+        textAnswer: null,
+        formulaAnswerJson: null,
+        fileUrl: null,
+      };
+    }
+
+    if (inputType === 'math_formula' || inputType === 'chem_formula') {
+      return {
+        textAnswer: null,
+        formulaAnswerJson: JSON.stringify({
+          type: inputType === 'chem_formula' ? 'chemistry' : 'formula',
+          value,
+        }),
+        fileUrl: null,
+      };
+    }
+
+    if (
+      inputType === 'voice_record' ||
+      inputType === 'handwritten' ||
+      value.startsWith('http://') ||
+      value.startsWith('https://') ||
+      value.startsWith('data:')
+    ) {
+      return {
+        textAnswer: null,
+        formulaAnswerJson: null,
+        fileUrl: value,
+      };
+    }
+
+    return {
+      textAnswer: value,
+      formulaAnswerJson: null,
+      fileUrl: null,
+    };
+  }
+
+  private normalizeIsoDate(value?: string | null) {
+    if (!value) {
+      return null;
+    }
+
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return date.toISOString();
   }
 
   private parseAnswers(value: string): OfflineDraftAnswers {


### PR DESCRIPTION
## What

Reconcile offline exam drafts and submissions into the live sync flow in the API.

## Why

To unify offline exam data handling with the live sync process and ensure drafts and submissions are synchronized more consistently.

## Changes

- Reconciled offline exam drafts into the live sync flow
- Reconciled offline exam submissions into the live sync flow
- Improved consistency between offline data handling and live synchronization

## How to test

1. Create or update offline exam drafts and submissions
2. Trigger the live sync flow
3. Verify the offline draft and submission data are reconciled correctly

## Notes

This change refactors sync behavior for offline exam data and does not introduce direct UI changes.

Closes #699 