### PR TITLE
chore(api): create or update dev users from local auth payloads

### DIFF
--- a/api/src/modules/user/user.service.ts
+++ b/api/src/modules/user/user.service.ts
@@ -15,6 +15,15 @@ interface ClerkUserPayload {
   role?: UserRole;
 }
 
+interface DevUserPayload {
+  id: string;
+  clerkUserId: string;
+  email: string;
+  name: string;
+  imageUrl?: string | null;
+  role?: UserRole;
+}
+
 @Injectable()
 export class UserService {
   constructor(private readonly userRepository: UserRepository) {}
@@ -102,6 +111,36 @@ export class UserService {
 
     const newUser: NewUser = {
       id: crypto.randomUUID(),
+      clerkUserId: payload.clerkUserId,
+      email: payload.email,
+      name: payload.name,
+      imageUrl: payload.imageUrl ?? null,
+      role: payload.role ?? 'student',
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    return this.userRepository.create(newUser);
+  }
+
+  async findOrCreateDevUser(payload: DevUserPayload) {
+    const existingUser = await this.userRepository.findById(payload.id);
+
+    if (existingUser) {
+      return this.userRepository.update(existingUser.id, {
+        clerkUserId: payload.clerkUserId,
+        email: payload.email,
+        name: payload.name,
+        imageUrl: payload.imageUrl ?? null,
+        role: payload.role ?? existingUser.role,
+      });
+    }
+
+    const now = new Date().toISOString();
+
+    const newUser: NewUser = {
+      id: payload.id,
       clerkUserId: payload.clerkUserId,
       email: payload.email,
       name: payload.name,


### PR DESCRIPTION
## What

Create or update development users from local auth payloads in the API.

## Why

To keep development user records in sync with local authentication payloads and improve non-production authentication workflows.

## Changes

- Added logic to create development users from local auth payloads
- Added logic to update existing development users when auth payloads change
- Improved support for local authentication in non-production environments

## How to test

1. Run the API in a local or non-production environment
2. Authenticate with a local auth payload for a new user and verify the user is created
3. Authenticate again with updated payload data and confirm the existing user is updated

## Notes

This change updates development authentication behavior and does not introduce direct UI changes.

Closes #701 