### PR TITLE
docs(web): document node version requirements for frontend dependencies

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,8 +1,22 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Requirements
+
+Use Node.js `>=21.7.3`.
+
+`mathlive` depends on `@cortex-js/compute-engine@0.30.2`, which does not install on Node 20.
+
 ## Getting Started
 
-First, run the development server:
+First, switch to a compatible Node version and install dependencies:
+
+```bash
+nvm install 22
+nvm use 22
+yarn install
+```
+
+Then run the development server:
 
 ```bash
 npm run dev


### PR DESCRIPTION
## What

Document the required Node.js version for frontend dependencies in `web/README.md`.

## Why

Frontend dependencies may fail to install or behave inconsistently when using an unsupported Node.js version. Adding this requirement to the README helps developers set up the project correctly and reduces environment-related issues.

## Changes

- Added Node.js version requirement documentation to `web/README.md`
- Clarified frontend setup expectations for local development
- Improved onboarding guidance for developers working in the `web` app

## How to test

1. Open `web/README.md`
2. Review the setup instructions for frontend development
3. Verify the Node.js version requirement is clearly documented and easy to find

## Notes

This is a documentation-only change and does not affect runtime behavior.

Closes #712 