### PR TITLE
chore(web): remove unused animation css import from global styles

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,5 +1,4 @@
 @import 'tailwindcss';
-@import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
## What

Remove an unused animation CSS import from `web/app/globals.css`.

## Why

The imported animation styles were no longer being used. Removing the unused import helps keep global styles clean, reduces unnecessary CSS inclusion, and makes the stylesheet easier to maintain.

## Changes

- Removed the unused animation CSS import from `web/app/globals.css`
- Cleaned up global stylesheet dependencies
- Reduced unused styling overhead in the web app

## How to test

1. Run the `web` app locally
2. Navigate through pages that use global styles
3. Verify the UI renders as expected and no animations or styles are unintentionally affected

## Notes

This is a cleanup change only. No visual changes are expected unless something was unintentionally relying on the unused import.

Closes #713 