### PR TITLE
refactor(web): simplify toast action type definitions on ui book

### DIFF
--- a/web/components/ui/use-toast.ts
+++ b/web/components/ui/use-toast.ts
@@ -15,13 +15,6 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
-const actionTypes = {
-  ADD_TOAST: 'ADD_TOAST',
-  UPDATE_TOAST: 'UPDATE_TOAST',
-  DISMISS_TOAST: 'DISMISS_TOAST',
-  REMOVE_TOAST: 'REMOVE_TOAST',
-} as const
-
 let count = 0
 
 function genId() {
@@ -29,23 +22,21 @@ function genId() {
   return count.toString()
 }
 
-type ActionType = typeof actionTypes
-
 type Action =
   | {
-      type: ActionType['ADD_TOAST']
+      type: 'ADD_TOAST'
       toast: ToasterToast
     }
   | {
-      type: ActionType['UPDATE_TOAST']
+      type: 'UPDATE_TOAST'
       toast: Partial<ToasterToast>
     }
   | {
-      type: ActionType['DISMISS_TOAST']
+      type: 'DISMISS_TOAST'
       toastId?: ToasterToast['id']
     }
   | {
-      type: ActionType['REMOVE_TOAST']
+      type: 'REMOVE_TOAST'
       toastId?: ToasterToast['id']
     }
 


### PR DESCRIPTION
## What

Simplify toast action type definitions in the UI hook.

## Why

To reduce type complexity and make the toast hook easier to understand and maintain.

## Changes

- Simplified toast action type definitions
- Reduced unnecessary complexity in the toast hook
- Improved maintainability of the UI hook

## How to test

1. Open the toast hook file
2. Verify the updated action type definitions
3. Run type checking and confirm toast usage still resolves correctly

## Notes

This change updates type definitions only and does not introduce UI behavior changes.

Closes #717 