### PR TITLE
feat(web): relax strict eslint rules blocking frontend development

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -22,39 +22,7 @@ const eslintConfig = defineConfig([
       ...tsEslintPlugin.configs.recommended.rules,
       ...nextEslintPluginNext.configs.recommended.rules,
       ...nextEslintPluginNext.configs["core-web-vitals"].rules,
-      "@typescript-eslint/naming-convention": [
-        "error",
-        {
-          selector: "variableLike",
-          format: ["camelCase", "PascalCase"],
-        },
-        {
-          selector: "function",
-          format: ["camelCase", "PascalCase"],
-        },
-        {
-          selector: "typeLike",
-          format: ["PascalCase"],
-        },
-      ],
-      "@typescript-eslint/no-explicit-any": "error",
-      complexity: ["error", 4],
-      "max-lines": [
-        "error",
-        {
-          max: 150,
-          skipBlankLines: true,
-          skipComments: true,
-        },
-      ],
-      "max-lines-per-function": [
-        "error",
-        {
-          max: 180,
-          skipBlankLines: true,
-          skipComments: true,
-        },
-      ],
+      "@typescript-eslint/no-explicit-any": "warn",
     },
   },
   {
@@ -63,23 +31,6 @@ const eslintConfig = defineConfig([
     rules: {
       ...nextEslintPluginNext.configs.recommended.rules,
       ...nextEslintPluginNext.configs["core-web-vitals"].rules,
-      complexity: ["error", 4],
-      "max-lines": [
-        "error",
-        {
-          max: 150,
-          skipBlankLines: true,
-          skipComments: true,
-        },
-      ],
-      "max-lines-per-function": [
-        "error",
-        {
-          max: 180,
-          skipBlankLines: true,
-          skipComments: true,
-        },
-      ],
     },
   },
   globalIgnores([


### PR DESCRIPTION
## What

Relax strict ESLint rules that were blocking frontend development.

## Why

To reduce unnecessary development friction and allow frontend work to proceed without being blocked by overly strict lint rules.

## Changes

- Relaxed selected ESLint rules
- Reduced tooling friction during frontend development
- Improved developer experience for the web app

## How to test

1. Open the ESLint configuration
2. Verify the updated rule settings
3. Run linting and confirm frontend development is no longer blocked by the targeted rules

## Notes

This change updates tooling configuration and does not affect runtime behavior.

Closes #718 