### PR TITLE
chore(web): remove unused dialog trigger import from admin classes page

### DIFF
--- a/web/features/admin/classes/AdminClassesClient.tsx
+++ b/web/features/admin/classes/AdminClassesClient.tsx
@@ -5,7 +5,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { DialogTrigger } from '@/components/ui/dialog'
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Search, Plus, Users, School } from 'lucide-react'
 import { initialClasses, initialUsers } from '@/lib/data'


### PR DESCRIPTION
## What

Remove an unused dialog trigger import from the admin classes page.

## Why

To clean up unused code and keep the admin classes page implementation simpler and easier to maintain.

## Changes

- Removed an unused dialog trigger import
- Cleaned up the admin classes page
- Reduced unnecessary code in the component

## How to test

1. Open the admin classes page file
2. Confirm the unused import has been removed
3. Run type checking or linting and verify there are no issues

## Notes

This is a cleanup-only change with no functional behavior changes.

Closes #719