### PR TITLE
chore(web): remove unused schoolclass type import from admin chart

### DIFF
--- a/web/features/admin/dashboard/_components/AdminClassChart.tsx
+++ b/web/features/admin/dashboard/_components/AdminClassChart.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
-import type { SchoolClass } from '@/lib/types'
 
 interface ClassRow { id: string; name: string; avg: number }
 


### PR DESCRIPTION
## What

Remove an unused `SchoolClass` type import from the admin chart component.

## Why

To clean up unused code and improve maintainability in the admin dashboard chart component.

## Changes

- Removed the unused `SchoolClass` type import
- Cleaned up the admin chart component
- Reduced unnecessary type noise in the file

## How to test

1. Open the admin chart component
2. Confirm the unused import has been removed
3. Run type checking or linting and verify the file passes

## Notes

This is a cleanup-only change with no functional behavior changes.

Closes #720 