### PR TITLE
chore(web): remove unused metric card icons from admin dashboard

### DIFF
--- a/web/features/admin/dashboard/_components/AdminMetricCards.tsx
+++ b/web/features/admin/dashboard/_components/AdminMetricCards.tsx
@@ -1,4 +1,4 @@
-import { TrendingUp, Users, FileText, School } from 'lucide-react'
+import { TrendingUp } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 type Stat = {


### PR DESCRIPTION
## What

Remove unused metric card icons from the admin dashboard.

## Why

To clean up the admin dashboard implementation and remove unused UI code that is no longer needed.

## Changes

- Removed unused metric card icons
- Simplified the admin dashboard component
- Reduced unnecessary UI code

## How to test

1. Open the admin metric cards component
2. Confirm the unused icons have been removed
3. Run the admin dashboard and verify the cards still render correctly

## Notes

This is a cleanup-only change with no intended behavior changes.

Closes #721 