### PR TITLE
chore(web): update exam bottom bar for new session controls layout

### DIFF
--- a/web/features/student/exam-taking/_components/ExamBottomBar.tsx
+++ b/web/features/student/exam-taking/_components/ExamBottomBar.tsx
@@ -1,3 +1,4 @@
+import type React from 'react'
 import { Bookmark, ChevronLeft, ChevronRight } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
@@ -6,6 +7,7 @@ interface ExamBottomBarProps {
   total: number
   isMarked: boolean
   lastSaved: Date | null
+  proctoringPreview?: React.ReactNode
   onPrev: () => void
   onNext: () => void
   onToggleMark: () => void
@@ -15,42 +17,53 @@ export function ExamBottomBar({
   currentIndex,
   total,
   isMarked,
+  proctoringPreview,
   onPrev,
   onNext,
   onToggleMark,
 }: ExamBottomBarProps) {
   return (
-    <div className="h-16 border-t border-card-border bg-white flex items-center justify-between px-6 shrink-0">
-      <button
-        onClick={onToggleMark}
-        className={cn(
-          "flex items-center gap-2 px-4 py-2 rounded-lg transition-colors",
-          isMarked
-            ? "text-amber-600 bg-amber-50"
-            : "text-text-secondary hover:bg-table-header"
-        )}
-      >
-        <Bookmark size={16} strokeWidth={1.5} fill={isMarked ? 'currentColor' : 'none'} />
-        <span className="text-[13px] font-medium">Тэмдэглэх</span>
-      </button>
+    <div className="shrink-0 border-t border-card-border bg-white px-4 py-4 md:px-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between md:gap-6">
+        <div className="flex flex-col gap-3">
+          <button
+            onClick={onToggleMark}
+            className={cn(
+              'flex items-center gap-2 rounded-lg px-4 py-2 transition-colors',
+              isMarked
+                ? 'bg-amber-50 text-amber-600'
+                : 'text-text-secondary hover:bg-table-header',
+            )}
+          >
+            <Bookmark
+              size={16}
+              strokeWidth={1.5}
+              fill={isMarked ? 'currentColor' : 'none'}
+            />
+            <span className="text-[13px] font-medium">Тэмдэглэх</span>
+          </button>
 
-      <div className="flex items-center gap-3">
-        <button
-          onClick={onPrev}
-          disabled={currentIndex === 0}
-          className="flex items-center gap-1.5 px-4 py-2 border border-card-border rounded-lg text-[13px] font-medium text-foreground hover:bg-table-header transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          <ChevronLeft size={16} strokeWidth={1.5} />
-          Өмнөх
-        </button>
-        <button
-          onClick={onNext}
-          disabled={currentIndex === total - 1}
-          className="flex items-center gap-1.5 px-4 py-2 bg-primary text-white rounded-lg text-[13px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          Дараах
-          <ChevronRight size={16} strokeWidth={1.5} />
-        </button>
+          {proctoringPreview}
+        </div>
+
+        <div className="flex items-center justify-between gap-3 md:justify-end">
+          <button
+            onClick={onPrev}
+            disabled={currentIndex === 0}
+            className="flex items-center gap-1.5 rounded-lg border border-card-border px-4 py-2 text-[13px] font-medium text-foreground transition-colors hover:bg-table-header disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <ChevronLeft size={16} strokeWidth={1.5} />
+            Өмнөх
+          </button>
+          <button
+            onClick={onNext}
+            disabled={currentIndex === total - 1}
+            className="flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-[13px] font-medium text-white transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Дараах
+            <ChevronRight size={16} strokeWidth={1.5} />
+          </button>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## What

Update the exam bottom bar for new session controls and layout.

## Why

To support the latest exam session actions and improve the bottom bar layout during exam-taking.

## Changes

- Updated the exam bottom bar layout
- Added support for new session controls
- Improved usability during the exam-taking flow

## How to test

1. Open the exam-taking screen
2. Verify the updated bottom bar layout
3. Confirm the new session controls are visible and work correctly

## Notes

This change updates the exam-taking UI layout and control surface.

Closes #725 