### PR TITLE
chore(web): align submit modal with updated exam submission states

### DIFF
--- a/web/features/student/exam-taking/_components/SubmitModal.tsx
+++ b/web/features/student/exam-taking/_components/SubmitModal.tsx
@@ -5,6 +5,7 @@ interface SubmitModalProps {
   answeredCount: number
   unansweredCount: number
   markedCount: number
+  isSubmitting?: boolean
   onCancel: () => void
   onConfirm: () => void
 }
@@ -14,6 +15,7 @@ export function SubmitModal({
   answeredCount,
   unansweredCount,
   markedCount,
+  isSubmitting,
   onCancel,
   onConfirm,
 }: SubmitModalProps) {
@@ -56,9 +58,10 @@ export function SubmitModal({
             </button>
             <button
               onClick={onConfirm}
+              disabled={isSubmitting}
               className="flex-1 py-3 bg-primary text-white text-[14px] font-medium rounded-xl hover:bg-primary/90 transition-colors"
             >
-              Дуусгах
+              {isSubmitting ? 'Илгээж байна...' : 'Дуусгах'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## What

Align the submit modal with updated exam submission states.

## Why

To ensure the submission confirmation flow reflects the latest submission logic and state transitions.

## Changes

- Updated the submit modal UI and state handling
- Aligned messaging with the current submission flow
- Improved consistency in the final exam submission experience

## How to test

1. Open the submit modal during exam-taking
2. Verify the content matches the current submission state
3. Confirm the modal behaves correctly across different submission scenarios

## Notes

This change updates exam submission UI behavior.

Closes #729 