### PR TITLE
chore(web): update local storing to support serialized api answer shapes

### DIFF
--- a/web/features/student/exam-taking/examScoring.ts
+++ b/web/features/student/exam-taking/examScoring.ts
@@ -1,5 +1,6 @@
 import { save } from '@/lib/data'
-import type { Attempt, Question, Result } from '@/lib/types'
+import type { Attempt, Result } from '@/lib/types'
+import type { StudentExamQuestion } from '@/lib/api/student-exams'
 
 export function scoreAndSave({
   exam,
@@ -11,8 +12,8 @@ export function scoreAndSave({
 }: {
   exam: { id: string; duration: number }
   assignment: { id: string } | null
-  questions: Question[]
-  answers: Record<string, string | string[]>
+  questions: StudentExamQuestion[]
+  answers: Record<string, string>
   timeRemaining: number
   currentStudentId: string
 }) {
@@ -52,7 +53,7 @@ export function scoreAndSave({
       }
     } else if (q.type === 'multiple') {
       const correct = q.correctAnswer as string[]
-      const userAnswer = (answer as string[]) || []
+      const userAnswer = answer ? (JSON.parse(answer) as string[]) : []
       if (JSON.stringify([...userAnswer].sort()) === JSON.stringify([...correct].sort())) {
         scorePerQuestion[q.id] = q.points
         totalScore += q.points


### PR DESCRIPTION
## What

Update local scoring to support serialized API answer shapes.

## Why

To keep local scoring compatible with the answer format returned or stored by the API.

## Changes

- Updated local scoring logic
- Added support for serialized API answer shapes
- Improved compatibility between frontend scoring and backend answer data

## How to test

1. Run local scoring against API-backed answer data
2. Verify serialized answers are scored correctly
3. Confirm existing supported answer formats still work as expected

## Notes

This change improves compatibility between local scoring and API answer models.

Closes #730 