### PR TITLE
chore(web): clarify empty state copy for unpublished student results

### DIFF
--- a/web/features/student/results/_components/ResultExamList.tsx
+++ b/web/features/student/results/_components/ResultExamList.tsx
@@ -56,7 +56,7 @@ export function ResultExamList({
             </button>
           )
         })}
-        {studentResults.length === 0 && <div className="text-center py-12 text-text-secondary text-[14px]">Үр дүн байхгүй байна.</div>}
+        {studentResults.length === 0 && <div className="text-center py-12 text-text-secondary text-[14px]">Ил гарсан үр дүн хараахан алга байна.</div>}
       </div>
     </div>
   )


### PR DESCRIPTION
## What

Clarify empty-state copy for unpublished student results.

## Why

To provide clearer messaging when results are not yet available or have not been published.

## Changes

- Updated empty-state messaging
- Improved clarity for unpublished result scenarios
- Refined student-facing copy on the results page

## How to test

1. Open the student results page with no published results
2. Verify the updated empty-state message is displayed
3. Confirm the message is clear and contextually accurate

## Notes

This change updates copy only and does not affect runtime behavior.

Closes #734 