### PR TITLE
feat(web): add top nav spacing fixes to the student shell layout

### DIFF
--- a/web/features/student/student-shell/StudentShellFeature.tsx
+++ b/web/features/student/student-shell/StudentShellFeature.tsx
@@ -23,7 +23,7 @@ export function StudentShellFeature({ children }: StudentShellFeatureProps) {
           navLinks={studentNavLinks}
           studentDisplayName={studentDisplayName}
         />
-        <main className="p-6">
+        <main className="px-4 pb-4 pt-[112px] md:px-6 md:pb-6 md:pt-[92px]">
           {children}
         </main>
       </div>


### PR DESCRIPTION
## What

Add top navigation spacing fixes to the student shell layout.

## Why

To improve layout consistency and prevent content from overlapping or misaligning with the student top navigation.

## Changes

- Adjusted spacing in the student shell layout
- Added top-nav layout fixes
- Improved page structure under the student navigation

## How to test

1. Open pages within the student shell
2. Verify content spacing below the top navigation is correct
3. Confirm the layout remains stable across screen sizes

## Notes

This change improves layout spacing and does not alter core feature logic.

Closes #735 