### PR TITLE
chore(web): remove unused course color import from class detail page

### DIFF
--- a/web/features/teacher/class-detail/ClassDetailClient.tsx
+++ b/web/features/teacher/class-detail/ClassDetailClient.tsx
@@ -7,7 +7,7 @@ import {
   initialClasses, initialCourses, initialExamAssignments, initialExams,
   initialUsers, initialAttempts, CURRENT_TEACHER_ID
 } from '@/lib/data'
-import { COURSE_COLORS, SUBJECT_NAMES } from '@/lib/constants'
+import { SUBJECT_NAMES } from '@/lib/constants'
 import { StudentRow } from './_components/StudentRow'
 import { ClassExamRow } from './_components/ClassExamRow'
 


### PR DESCRIPTION
## What

Remove an unused course color import from the class detail page.

## Why

To clean up unused code and improve maintainability in the teacher class detail page.

## Changes

- Removed the unused course color import
- Cleaned up the class detail page file
- Reduced unnecessary code in the component

## How to test

1. Open the class detail page file
2. Confirm the unused import has been removed
3. Run type checking or linting and verify there are no issues

## Notes

This is a cleanup-only change with no functional behavior changes.

Closes #737 