### PR TITLE
chore(web): remove unused questions prop from create exam question step

### DIFF
--- a/web/features/teacher/create-exam/_components/StepQuestions.tsx
+++ b/web/features/teacher/create-exam/_components/StepQuestions.tsx
@@ -10,7 +10,7 @@ import { QuestionTabFile } from './QuestionTabFile'
 type QuestionTab = 'new' | 'bank' | 'ai' | 'file'
 
 export function StepQuestions({
-  questions, questionTab, questionText, questionType, questionOptions, correctAnswer, questionPoints,
+  questionTab, questionText, questionType, questionOptions, correctAnswer, questionPoints,
   bankSearchQuery, selectedBankQuestions, filteredBankQuestions,
   aiTopic, aiDifficulty, aiCount, aiGenerating, aiGeneratedQuestions,
   importingFile, importFileName,
@@ -19,7 +19,7 @@ export function StepQuestions({
   onAiTopic, onAiDifficulty, onAiCount, onAiGenerate, onAddAiQuestions,
   onFileUpload, onFolderUpload, onDemo,
 }: {
-  questions: Question[]; questionTab: QuestionTab; questionText: string; questionType: QuestionType
+  questionTab: QuestionTab; questionText: string; questionType: QuestionType
   questionOptions: string[]; correctAnswer: string | string[]; questionPoints: number
   bankSearchQuery: string; selectedBankQuestions: string[]; filteredBankQuestions: Question[]
   aiTopic: string; aiDifficulty: 'easy' | 'medium' | 'hard'; aiCount: number; aiGenerating: boolean; aiGeneratedQuestions: Question[]


### PR DESCRIPTION
## What

Remove the unused `questions` prop from the create exam question step.

## Why

To simplify component props and remove unused inputs from the question step implementation.

## Changes

- Removed the unused `questions` prop
- Simplified the create exam question step component
- Reduced unnecessary prop surface area

## How to test

1. Open the question step component
2. Confirm the unused prop has been removed
3. Run type checking and verify the create exam flow still works correctly

## Notes

This is a refactor-only change with no intended behavior changes.

Closes #739 