### PR TITLE
chore(web): simplify grading area props to current question context only

### DIFF
--- a/web/features/teacher/exam-detail/_components/QuestionGradingArea.tsx
+++ b/web/features/teacher/exam-detail/_components/QuestionGradingArea.tsx
@@ -5,8 +5,8 @@ import { QUESTION_TYPE_LABELS } from '@/lib/types'
 
 type AnswerItem = { questionId: string; answer: string | string[] }
 
-export function QuestionGradingArea({ questions, currentQuestion, currentQuestionIndex, currentAnswer, feedback, onScoreChange, onCommentChange }: {
-  questions: Question[]; currentQuestion: Question | undefined; currentQuestionIndex: number
+export function QuestionGradingArea({ currentQuestion, currentQuestionIndex, currentAnswer, feedback, onScoreChange, onCommentChange }: {
+  currentQuestion: Question | undefined; currentQuestionIndex: number
   currentAnswer: AnswerItem | null; feedback: Record<string, { score: number; comment: string }>
   onScoreChange: (questionId: string, score: number) => void; onCommentChange: (questionId: string, comment: string) => void
 }) {


### PR DESCRIPTION
## What

Simplify grading area props to use only the current-question context.

## Why

To reduce prop complexity and make the grading area component easier to reason about and maintain.

## Changes

- Simplified grading area props
- Reduced the component to current-question context only
- Improved maintainability of the grading UI

## How to test

1. Open the grading area component
2. Verify the updated props and current-question context usage
3. Run the grading flow and confirm behavior remains correct

## Notes

This change refactors component structure without changing the overall grading workflow.

Closes #743 