### PR TITLE
chore(web): remove unused type imports from teacher exam list

### DIFF
--- a/web/features/teacher/exam-list/ExamListClient.tsx
+++ b/web/features/teacher/exam-list/ExamListClient.tsx
@@ -6,7 +6,6 @@ import { cn } from '@/lib/utils'
 import { Plus, Search } from 'lucide-react'
 import { initialExamAssignments, initialExams, initialClasses, initialCourses, initialResults, CURRENT_TEACHER_ID } from '@/lib/data'
 import { ExamCard } from './_components/ExamCard'
-import type { ExamAssignment, Exam, SchoolClass, Course } from '@/lib/types'
 
 type FilterTab = 'all' | 'scheduled' | 'active' | 'closed'
 


### PR DESCRIPTION
## What

Remove unused type imports from the teacher exam list.

## Why

To clean up unused code and keep the exam list implementation simpler and easier to maintain.

## Changes

- Removed unused type imports
- Cleaned up the teacher exam list file
- Reduced unnecessary type noise

## How to test

1. Open the teacher exam list file
2. Confirm the unused imports have been removed
3. Run type checking or linting and verify there are no issues

## Notes

This is a cleanup-only change with no functional behavior changes.

Closes #744