### PR TITLE
chore(web): remove unused owner prop from exam banner usage

### DIFF
--- a/web/features/teacher/question-detail/QuestionDetailClient.tsx
+++ b/web/features/teacher/question-detail/QuestionDetailClient.tsx
@@ -45,7 +45,7 @@ export function QuestionDetailClient({ params }: { params: Promise<{ id: string 
         <ChevronLeft size={16} strokeWidth={1.5} />Шалгалтын сан руу буцах
       </Link>
 
-      <ExamBanner exam={exam} subject={subject} owner={owner} subjectColor={subjectColor} isOwner={isOwner} />
+      <ExamBanner exam={exam} subject={subject} subjectColor={subjectColor} isOwner={isOwner} />
 
       <div className="grid grid-cols-4 gap-4 mb-6">
         {[


### PR DESCRIPTION
## What

Remove an unused owner prop from exam banner usage.

## Why

To clean up component usage and remove unnecessary data passing in the question detail flow.

## Changes

- Removed the unused owner prop from exam banner usage
- Simplified question detail component wiring
- Reduced unnecessary prop passing

## How to test

1. Open the question detail implementation
2. Confirm the unused owner prop has been removed
3. Run type checking and verify the page still works correctly

## Notes

This is a cleanup-only change with no functional behavior changes.

Closes #748 