### PR TITLE
refactor(web): simplify exam banner props by removing unused owner data

### DIFF
--- a/web/features/teacher/question-detail/_components/ExamBanner.tsx
+++ b/web/features/teacher/question-detail/_components/ExamBanner.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link'
 import { Edit, Copy, Printer, Calendar, Lock, Globe } from 'lucide-react'
-import type { Exam, User } from '@/lib/types'
+import type { Exam } from '@/lib/types'
 
 type Subject = { id: string; name: string }
-export function ExamBanner({ exam, subject, owner, subjectColor, isOwner }: {
-  exam: Exam; subject: Subject | null; owner: User | null; subjectColor: string; isOwner: boolean
+export function ExamBanner({ exam, subject, subjectColor, isOwner }: {
+  exam: Exam; subject: Subject | null; subjectColor: string; isOwner: boolean
 }) {
   return (
     <div className="bg-white border rounded-[10px] overflow-hidden mb-6" style={{ borderColor: '#DDE1E7' }}>


### PR DESCRIPTION
## What

Simplify exam banner props by removing unused owner data.

## Why

To reduce component complexity and avoid passing data that is no longer needed.

## Changes

- Removed unused owner data from exam banner props
- Simplified the component interface
- Improved maintainability of the exam banner

## How to test

1. Open the exam banner component
2. Verify the updated prop shape
3. Run the related teacher flows and confirm the banner still renders correctly

## Notes

This is a refactor-only change with no intended behavior changes.

Closes #749 