### PR TITLE
chore(web): make teacher sidebar sticky under the platform header

### DIFF
--- a/web/features/teacher/teacher-shell/components/TeacherSidebar.tsx
+++ b/web/features/teacher/teacher-shell/components/TeacherSidebar.tsx
@@ -31,10 +31,10 @@ export function TeacherSidebar({
   return (
     <aside
       className={cn(
-        'bg-white border-r flex flex-col transition-all duration-200',
+        'bg-white border-r flex flex-col transition-all duration-200 md:sticky md:top-9 md:self-start',
         isMobile ? 'w-[220px]' : collapsed ? 'w-14' : 'w-[220px]'
       )}
-      style={{ borderColor: '#DDE1E7', minHeight: 'calc(100vh - 36px)' }}
+      style={{ borderColor: '#DDE1E7', minHeight: 'calc(100vh - 36px)', height: 'calc(100vh - 36px)' }}
     >
       <div
         className={cn('p-4 border-b', collapsed && !isMobile && 'px-2')}


### PR DESCRIPTION
## What

Make the teacher sidebar sticky under the platform header.

## Why

To improve navigation usability and keep the teacher sidebar accessible while scrolling.

## Changes

- Updated the teacher sidebar to be sticky
- Positioned the sidebar under the platform header
- Improved usability of teacher navigation

## How to test

1. Open a page using the teacher shell
2. Scroll through the content
3. Verify the sidebar remains visible and positioned correctly under the platform header

## Notes

This change improves teacher navigation layout and does not alter feature logic.

Closes #751 