### PR TITLE
chore(web): simplify toast hook action type definitions

### DIFF
--- a/web/hooks/use-toast.ts
+++ b/web/hooks/use-toast.ts
@@ -15,13 +15,6 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
-const actionTypes = {
-  ADD_TOAST: 'ADD_TOAST',
-  UPDATE_TOAST: 'UPDATE_TOAST',
-  DISMISS_TOAST: 'DISMISS_TOAST',
-  REMOVE_TOAST: 'REMOVE_TOAST',
-} as const
-
 let count = 0
 
 function genId() {
@@ -29,23 +22,21 @@ function genId() {
   return count.toString()
 }
 
-type ActionType = typeof actionTypes
-
 type Action =
   | {
-      type: ActionType['ADD_TOAST']
+      type: 'ADD_TOAST'
       toast: ToasterToast
     }
   | {
-      type: ActionType['UPDATE_TOAST']
+      type: 'UPDATE_TOAST'
       toast: Partial<ToasterToast>
     }
   | {
-      type: ActionType['DISMISS_TOAST']
+      type: 'DISMISS_TOAST'
       toastId?: ToasterToast['id']
     }
   | {
-      type: ActionType['REMOVE_TOAST']
+      type: 'REMOVE_TOAST'
       toastId?: ToasterToast['id']
     }
 


### PR DESCRIPTION
## What

Simplify shared toast hook action type definitions.

## Why

To reduce unnecessary type complexity and make the shared toast hook easier to maintain.

## Changes

- Simplified shared toast action type definitions
- Reduced complexity in the toast hook
- Improved maintainability of shared UI types

## How to test

1. Open the shared toast hook file
2. Verify the updated action type definitions
3. Run type checking and confirm toast usage still resolves correctly

## Notes

This change updates type definitions only and does not alter user-facing behavior.

Closes #752 