### PR TITLE
bug(web): fix corrupted mongolian chemistry seed exam title

### DIFF
--- a/web/lib/data/seed-exams-part-a.ts
+++ b/web/lib/data/seed-exams-part-a.ts
@@ -47,7 +47,7 @@ export const seedExamsPartA: Exam[] = [
   },
   { 
     id: 'E25ХИМ0001', 
-    title: 'Хими — Орган����к нэгдлүүд', 
+    title: 'Хими — Органик нэгдлүүд', 
     subjectId: 'ХИМ',
     grade: 10,
     chapter: '5-р бүлэг',


### PR DESCRIPTION
## What

Fix a corrupted Mongolian chemistry seed exam title.

## Why

To correct invalid or broken seed data and ensure the exam title is displayed properly.

## Changes

- Corrected the corrupted seed exam title
- Improved seed data quality for the chemistry exam
- Fixed displayed exam metadata

## How to test

1. Open the seed exam data file
2. Verify the Mongolian chemistry title is corrected
3. Run the related flow and confirm the exam title displays correctly

## Notes

This change fixes seed data only and does not alter runtime logic.

Closes #754 