### PR TITLE
docs(web): enforce minimum nodejs version for frontend builds

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,9 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=21.7.3"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## What

Enforce a minimum Node.js version for frontend builds.

## Why

To ensure the frontend is built and run with a supported Node.js version and avoid environment-specific issues.

## Changes

- Added a minimum Node.js version requirement
- Improved build environment consistency
- Reduced issues caused by unsupported runtime versions

## How to test

1. Open `package.json`
2. Verify the Node.js version requirement is defined
3. Run the project with supported and unsupported versions and confirm the expected behavior

## Notes

This change updates project tooling requirements and does not affect application runtime logic directly.

Closes #755 