### PR TITLE
feat(web): add application icon asset for metadata

### DIFF
--- a/web/app/icon.svg
+++ b/web/app/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <rect width="256" height="256" rx="48" fill="#0A2D6E"/>
+  <path d="M64 82h128v22H64zm0 48h92v22H64zm0 48h128v22H64z" fill="#ffffff"/>
+  <circle cx="188" cy="141" r="28" fill="#3B82F6"/>
+  <path d="M176 141h24m-12-12v24" stroke="#ffffff" stroke-width="10" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## What

Add an application icon asset for PWA metadata.

## Why

To support installable web app metadata and provide the required icon asset for the PWA experience.

## Changes

- Added a new application icon asset
- Supported PWA metadata requirements
- Improved installable app presentation

## How to test

1. Open the icon asset file
2. Verify the asset exists and is referenced correctly
3. Run the app and confirm the icon is used in the relevant PWA metadata context

## Notes

This change adds a static asset and does not alter application logic.

Closes #756 