### PR TITLE
chore(web): reigster service worker and sync offline exam queues on r…

### DIFF
--- a/web/components/pwa-provider.tsx
+++ b/web/components/pwa-provider.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useEffect } from 'react'
+import { syncOfflineExamQueue } from '@/lib/pwa/offline-exam'
+
+export function PwaProvider() {
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) {
+      return
+    }
+
+    void navigator.serviceWorker.register('/sw.js').catch(() => null)
+  }, [])
+
+  useEffect(() => {
+    const sync = () => {
+      void syncOfflineExamQueue().catch(() => null)
+    }
+
+    sync()
+    window.addEventListener('online', sync)
+    window.addEventListener('focus', sync)
+
+    return () => {
+      window.removeEventListener('online', sync)
+      window.removeEventListener('focus', sync)
+    }
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
## What

Register the service worker and sync offline exam queues on reconnect.

## Why

To support offline functionality and ensure queued exam actions are synchronized when connectivity returns.

## Changes

- Registered the service worker
- Added reconnect-based offline queue syncing
- Improved reliability of offline exam workflows

## How to test

1. Open the app and verify the service worker is registered
2. Perform offline exam actions while disconnected
3. Reconnect and confirm queued actions are synced successfully

## Notes

This change improves offline support and background sync behavior for the frontend.

Closes #758 