### PR TITLE
feat(web): add web app manifest for installable frontend experience

### DIFF
--- a/web/app/manifest.ts
+++ b/web/app/manifest.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from 'next'
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'e-Shalgalt',
+    short_name: 'e-Shalgalt',
+    description: 'Монгол улсын боловсролын үндэсний шалгалт, үнэлгээний платформ',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#F0F2F5',
+    theme_color: '#0A2D6E',
+    lang: 'mn',
+    orientation: 'portrait',
+    icons: [
+      {
+        src: '/icon.svg',
+        sizes: 'any',
+        type: 'image/svg+xml',
+        purpose: 'any',
+      },
+    ],
+  }
+}


### PR DESCRIPTION
## What

Add a web app manifest for an installable frontend experience.

## Why

To support PWA installation and provide the metadata required for an installable web application.

## Changes

- Added a web app manifest
- Configured installable app metadata
- Improved PWA support for the frontend

## How to test

1. Open the manifest implementation
2. Verify the expected PWA metadata is defined
3. Run the app and confirm installability-related behavior is available in supported browsers

## Notes

This change adds PWA configuration and does not alter core product logic.

Closes #757 