### PR TITLE
chore(web): reigster service worker and sync offline exam queues on r…

### DIFF
--- a/web/features/student/exam-taking/_components/AnswerChemistry.tsx
+++ b/web/features/student/exam-taking/_components/AnswerChemistry.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const ChemistryEditorClient = dynamic(
+  () => import('./ChemistryEditorClient').then((mod) => mod.ChemistryEditorClient),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-[420px] items-center justify-center rounded-xl border border-card-border bg-white text-[14px] text-text-secondary">
+        Chemistry editor ачааллаж байна...
+      </div>
+    ),
+  },
+)
+
+export function AnswerChemistry({
+  value,
+  onChange,
+}: {
+  value: string
+  onChange: (value: string) => void
+}) {
+  return <ChemistryEditorClient value={value} onChange={onChange} />
+}


### PR DESCRIPTION
## What

Register the service worker and sync offline exam queues on reconnect.

## Why

To support offline functionality and ensure queued exam actions are synchronized when connectivity returns.

## Changes

- Registered the service worker
- Added reconnect-based offline queue syncing
- Improved reliability of offline exam workflows

## How to test

1. Open the app and verify the service worker is registered
2. Perform offline exam actions while disconnected
3. Reconnect and confirm queued actions are synced successfully

## Notes

This change improves offline support and background sync behavior for the frontend.

Closes #759 