### PR TITLE
feat(web): add student exam api client and offline queue utilities

### DIFF
--- a/web/lib/api/client.ts
+++ b/web/lib/api/client.ts
@@ -1,0 +1,92 @@
+import {
+  CURRENT_STUDENT_ID,
+  CURRENT_TEACHER_ID,
+  getCurrentStudent,
+  getCurrentTeacher,
+} from "@/lib/data";
+
+type DevRole = "student" | "teacher";
+
+export function getApiUrl(path: string) {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL?.trim();
+
+  if (!baseUrl) {
+    return "";
+  }
+
+  return `${baseUrl.replace(/\/$/, "")}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+export function isApiConfigured() {
+  return Boolean(process.env.NEXT_PUBLIC_API_BASE_URL?.trim());
+}
+
+function createDevTokenPayload(role: DevRole) {
+  const user = role === "teacher" ? getCurrentTeacher() : getCurrentStudent();
+
+  const userId = role === "teacher" ? CURRENT_TEACHER_ID : CURRENT_STUDENT_ID;
+  const emailPrefix = role === "teacher" ? "teacher" : "student";
+
+  return {
+    userId,
+    email: `${emailPrefix}.${userId.toLowerCase()}@seedcone.local`,
+    role,
+    name: user?.name ?? userId,
+  };
+}
+
+export function getDevAuthToken(role: DevRole = "student") {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  const existing = window.localStorage.getItem("seedcone.dev_auth_token");
+  if (existing) {
+    return existing;
+  }
+
+  const token = btoa(JSON.stringify(createDevTokenPayload(role)));
+  window.localStorage.setItem("seedcone.dev_auth_token", token);
+  return token;
+}
+
+export function getAuthHeaders(role: DevRole = "student") {
+  const token = getDevAuthToken(role);
+
+  return token
+    ? {
+        Authorization: `Bearer ${token}`,
+      }
+    : {};
+}
+
+export async function apiFetch<T>(
+  path: string,
+  init?: RequestInit,
+  role: DevRole = "student",
+) {
+  const url = getApiUrl(path);
+
+  if (!url) {
+    throw new Error("NEXT_PUBLIC_API_BASE_URL is not configured.");
+  }
+
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      ...(init?.headers ?? {}),
+      ...getAuthHeaders(role),
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `Request failed with status ${response.status}`);
+  }
+
+  if (response.status === 204) {
+    return null as T;
+  }
+
+  return response.json() as Promise<T>;
+}

--- a/web/lib/api/student-exams.ts
+++ b/web/lib/api/student-exams.ts
@@ -1,0 +1,258 @@
+import { apiFetch, getApiUrl, getAuthHeaders, isApiConfigured } from '@/lib/api/client'
+
+export interface StudentExamQuestion {
+  id: string
+  text: string
+  type: 'single' | 'multiple' | 'truefalse' | 'matching' | 'short' | 'long' | 'formula' | 'chemistry' | 'code' | 'voice' | 'video' | 'handwritten'
+  points: number
+  order: number
+  options?: string[]
+  matchingPairs?: { left: string; right: string }[]
+  correctAnswer?: string | string[] | null
+}
+
+export interface StudentExamSummary {
+  exam: {
+    id: string
+    title: string
+    subjectId: string
+    subject: string
+    durationMinutes: number
+    startsAt: string | null
+    endsAt: string | null
+  }
+  session: {
+    id: string
+    status: string
+    startedAt: string | null
+    submittedAt: string | null
+  } | null
+  enrolledAt: string
+  attemptStatus: 'upcoming' | 'ready' | 'in_progress' | 'submitted' | 'force_submitted' | 'closed'
+  timing: {
+    timeRemainingSeconds: number
+  } | null
+}
+
+interface ApiAttemptResponse {
+  exam: {
+    id: string
+    title: string
+    subject: string
+    teacherId: string
+    durationMinutes: number
+  }
+  session: {
+    id: string
+    status: string
+    startedAt: string | null
+    submittedAt: string | null
+  }
+  questions: Array<{
+    id: string
+    content: string
+    inputType: string
+    points: number
+    orderIndex: number
+    optionsJson?: string | null
+    correctAnswer?: string | null
+  }>
+  answers: Array<{
+    questionId: string
+    textAnswer?: string | null
+    formulaAnswerJson?: string | null
+    fileUrl?: string | null
+  }>
+  timing: {
+    timeRemainingSeconds: number
+  }
+}
+
+function mapInputType(inputType: string): StudentExamQuestion['type'] {
+  switch (inputType) {
+    case 'mcq':
+      return 'single'
+    case 'short_text':
+      return 'short'
+    case 'rich_text':
+      return 'long'
+    case 'math_formula':
+      return 'formula'
+    case 'chem_formula':
+      return 'chemistry'
+    case 'voice_record':
+      return 'voice'
+    case 'handwritten':
+      return 'handwritten'
+    default:
+      return 'short'
+  }
+}
+
+function parseMaybeJson<T>(value?: string | null, fallback?: T): T | undefined {
+  if (!value) {
+    return fallback
+  }
+
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return fallback
+  }
+}
+
+export function mapAttemptToQuestionList(attempt: ApiAttemptResponse): StudentExamQuestion[] {
+  return attempt.questions
+    .slice()
+    .sort((left, right) => left.orderIndex - right.orderIndex)
+    .map((question) => ({
+      id: question.id,
+      text: question.content,
+      type: mapInputType(question.inputType),
+      points: question.points,
+      order: question.orderIndex,
+      options: parseMaybeJson<string[]>(question.optionsJson, []),
+      correctAnswer: null,
+    }))
+}
+
+export function mapAttemptToAnswerMap(attempt: ApiAttemptResponse) {
+  return attempt.answers.reduce<Record<string, string>>((result, answer) => {
+    result[answer.questionId] =
+      answer.textAnswer ??
+      answer.formulaAnswerJson ??
+      answer.fileUrl ??
+      ''
+    return result
+  }, {})
+}
+
+export async function fetchAssignedExams() {
+  const data = await apiFetch<StudentExamSummary[]>('/exams/assigned/me')
+
+  return data.map((item) => ({
+    ...item,
+    exam: {
+      ...item.exam,
+      subjectId: item.exam.subject,
+    },
+  }))
+}
+
+export async function startExamSession(examId: string) {
+  return apiFetch<{ id: string; status: string; startedAt: string | null }>(`/sessions/exam/${examId}/start`, {
+    method: 'POST',
+  })
+}
+
+export async function fetchExamAttempt(sessionId: string) {
+  return apiFetch<ApiAttemptResponse>(`/sessions/${sessionId}/attempt`)
+}
+
+export async function submitExamSession(sessionId: string) {
+  return apiFetch(`/sessions/${sessionId}/submit`, {
+    method: 'PATCH',
+  })
+}
+
+export async function autosaveExamAnswer(params: {
+  sessionId: string
+  question: StudentExamQuestion
+  value: string
+}) {
+  const payload: {
+    sessionId: string
+    questionId: string
+    textAnswer?: string
+    formulaAnswerJson?: string
+    fileUrl?: string
+  } = {
+    sessionId: params.sessionId,
+    questionId: params.question.id,
+  }
+
+  if (params.question.type === 'formula' || params.question.type === 'chemistry' || params.question.type === 'matching') {
+    payload.formulaAnswerJson = params.value
+  } else if (params.question.type === 'voice' || params.question.type === 'video' || params.question.type === 'handwritten') {
+    payload.fileUrl = params.value
+  } else {
+    payload.textAnswer = params.value
+  }
+
+  return apiFetch('/answers/autosave', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+}
+
+export async function uploadAnswerAsset(file: File, kind?: string) {
+  const url = getApiUrl('/answers/upload')
+
+  if (!url) {
+    throw new Error('NEXT_PUBLIC_API_BASE_URL is not configured.')
+  }
+
+  const formData = new FormData()
+  formData.append('file', file)
+  if (kind) {
+    formData.append('kind', kind)
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      ...getAuthHeaders('student'),
+    },
+    body: formData,
+  })
+
+  if (!response.ok) {
+    throw new Error(await response.text())
+  }
+
+  return response.json() as Promise<{ url: string }>
+}
+
+export async function runPreviewCode(code: string) {
+  return apiFetch<{ logs: string[]; result: unknown; error: string | null }>('/code/run', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      code,
+      mode: 'preview',
+    }),
+  })
+}
+
+export async function createProctoringViolation(params: {
+  studentId: string
+  examId: string
+  sessionId?: string
+  type: 'tab_switch' | 'window_blur'
+  teacherId?: string
+  studentName?: string
+  examTitle?: string
+  assignmentId?: string
+}) {
+  if (!isApiConfigured()) {
+    return null
+  }
+
+  return apiFetch('/monitoring/events', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      sessionId: params.sessionId ?? `${params.examId}:${params.studentId}`,
+      studentId: params.studentId,
+      examId: params.examId,
+      eventType: params.type,
+    }),
+  })
+}

--- a/web/lib/data/seed-init.ts
+++ b/web/lib/data/seed-init.ts
@@ -42,6 +42,10 @@ export function initializeData(): void {
   mergeSeedItems('submissions', seedSubmissions)
   mergeSeedItems('results', seedResults)
 
+  if (getAll('notifications').length === 0) {
+    localStorage.setItem('notifications', JSON.stringify([]))
+  }
+
   if (getAll<Schedule>('schedules').length === 0) {
     localStorage.setItem('schedules', JSON.stringify(seedSchedules))
   }

--- a/web/lib/notifications.ts
+++ b/web/lib/notifications.ts
@@ -1,0 +1,113 @@
+import { getAll } from '@/lib/data/local-storage'
+import type { AppNotification, Exam, SchoolClass } from '@/lib/types'
+
+const NOTIFICATIONS_KEY = 'notifications'
+const NOTIFICATION_EVENT = 'seedcone:notifications-changed'
+
+function emitNotificationsChanged() {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.dispatchEvent(new CustomEvent(NOTIFICATION_EVENT))
+}
+
+export function getNotificationEventName() {
+  return NOTIFICATION_EVENT
+}
+
+export function getNotifications(recipientId?: string): AppNotification[] {
+  const notifications = getAll<AppNotification>(NOTIFICATIONS_KEY)
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+
+  if (!recipientId) {
+    return notifications
+  }
+
+  return notifications.filter((item) => item.recipientId === recipientId)
+}
+
+export function saveNotifications(items: AppNotification[]) {
+  if (typeof window === 'undefined' || items.length === 0) {
+    return
+  }
+
+  const existing = getNotifications()
+  const existingIds = new Set(existing.map((item) => item.id))
+  const merged = [...existing]
+
+  for (const item of items) {
+    if (!existingIds.has(item.id)) {
+      merged.push(item)
+    }
+  }
+
+  if (merged.length === existing.length) {
+    return
+  }
+
+  localStorage.setItem(NOTIFICATIONS_KEY, JSON.stringify(merged))
+  emitNotificationsChanged()
+}
+
+export function markNotificationRead(notificationId: string) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  let hasChanged = false
+  const updated = getNotifications().map((item) =>
+    item.id === notificationId && !item.isRead
+      ? (hasChanged = true, { ...item, isRead: true })
+      : item,
+  )
+
+  if (!hasChanged) {
+    return
+  }
+
+  localStorage.setItem(NOTIFICATIONS_KEY, JSON.stringify(updated))
+  emitNotificationsChanged()
+}
+
+export function markAllNotificationsRead(recipientId: string) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  let hasChanged = false
+  const updated = getNotifications().map((item) =>
+    item.recipientId === recipientId && !item.isRead
+      ? (hasChanged = true, { ...item, isRead: true })
+      : item,
+  )
+
+  if (!hasChanged) {
+    return
+  }
+
+  localStorage.setItem(NOTIFICATIONS_KEY, JSON.stringify(updated))
+  emitNotificationsChanged()
+}
+
+export function buildExamAssignmentNotifications(params: {
+  exam: Exam
+  selectedClasses: SchoolClass[]
+}) {
+  const { exam, selectedClasses } = params
+  const createdAt = new Date().toISOString()
+
+  return selectedClasses.flatMap((schoolClass) =>
+    schoolClass.studentIds.map<AppNotification>((studentId) => ({
+      id: `notif-${exam.id}-${schoolClass.id}-${studentId}`,
+      recipientId: studentId,
+      title: 'Шинэ шалгалт оноогдлоо',
+      body: `"${exam.title}" шалгалт ${schoolClass.name} дээр нэмэгдлээ.`,
+      type: 'exam_assigned',
+      examId: exam.id,
+      classId: schoolClass.id,
+      isRead: false,
+      createdAt,
+    })),
+  )
+}

--- a/web/lib/pwa/offline-exam.ts
+++ b/web/lib/pwa/offline-exam.ts
@@ -1,0 +1,149 @@
+import { apiFetch, isApiConfigured } from '@/lib/api/client'
+import type { StudentExamQuestion } from '@/lib/api/student-exams'
+
+const ATTEMPT_CACHE_KEY = 'seedcone.offline.attempts'
+const DRAFT_QUEUE_KEY = 'seedcone.offline.drafts'
+const SUBMISSION_QUEUE_KEY = 'seedcone.offline.submissions'
+
+type CachedAttempt = {
+  exam: {
+    id: string
+    title: string
+    subjectId: string
+    duration: number
+    teacherId?: string
+  }
+  sessionId: string | null
+  assignmentId: string
+  questions: StudentExamQuestion[]
+  answers: Record<string, string>
+  timeRemaining: number
+  startedAt: string
+}
+
+type DraftQueueItem = {
+  draftKey: string
+  assignmentId: string
+  examId: string
+  studentId: string
+  answers: Record<string, string>
+  markedForReview: string[]
+  currentIndex: number
+  startedAt: string
+  updatedAt: string
+}
+
+type SubmissionQueueItem = {
+  assignmentId: string
+  examId: string
+  studentId: string
+  attempt: Record<string, unknown>
+  result: Record<string, unknown>
+  queuedAt: string
+}
+
+function readStore<T>(key: string): T[] {
+  if (typeof window === 'undefined') {
+    return []
+  }
+
+  const raw = window.localStorage.getItem(key)
+  if (!raw) {
+    return []
+  }
+
+  try {
+    return JSON.parse(raw) as T[]
+  } catch {
+    return []
+  }
+}
+
+function writeStore<T>(key: string, items: T[]) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.localStorage.setItem(key, JSON.stringify(items))
+}
+
+export function cacheExamAttempt(examId: string, studentId: string, attempt: CachedAttempt) {
+  const key = `${studentId}:${examId}`
+  const items = readStore<Array<{ key: string; value: CachedAttempt }>>(ATTEMPT_CACHE_KEY)
+  const next = items.filter((item) => item.key !== key)
+  next.push({ key, value: attempt })
+  writeStore(ATTEMPT_CACHE_KEY, next)
+}
+
+export function readCachedExamAttempt(examId: string, studentId: string) {
+  const key = `${studentId}:${examId}`
+  const items = readStore<Array<{ key: string; value: CachedAttempt }>>(ATTEMPT_CACHE_KEY)
+  return items.find((item) => item.key === key)?.value ?? null
+}
+
+export function queueOfflineDraft(item: DraftQueueItem) {
+  const items = readStore<DraftQueueItem>(DRAFT_QUEUE_KEY)
+  const next = items.filter((draft) => draft.draftKey !== item.draftKey)
+  next.push(item)
+  writeStore(DRAFT_QUEUE_KEY, next)
+}
+
+export function queueOfflineSubmission(item: SubmissionQueueItem) {
+  const items = readStore<SubmissionQueueItem>(SUBMISSION_QUEUE_KEY)
+  const next = items.filter(
+    (submission) =>
+      !(submission.assignmentId === item.assignmentId && submission.studentId === item.studentId),
+  )
+  next.push(item)
+  writeStore(SUBMISSION_QUEUE_KEY, next)
+}
+
+export async function syncOfflineExamQueue() {
+  if (!isApiConfigured() || typeof window === 'undefined' || !navigator.onLine) {
+    return
+  }
+
+  const drafts = readStore<DraftQueueItem>(DRAFT_QUEUE_KEY)
+  const submissions = readStore<SubmissionQueueItem>(SUBMISSION_QUEUE_KEY)
+
+  const remainingDrafts: DraftQueueItem[] = []
+  for (const draft of drafts) {
+    try {
+      await apiFetch('/offline-exam-sync/draft', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(draft),
+      })
+    } catch {
+      remainingDrafts.push(draft)
+    }
+  }
+
+  writeStore(DRAFT_QUEUE_KEY, remainingDrafts)
+
+  const remainingSubmissions: SubmissionQueueItem[] = []
+  for (const submission of submissions) {
+    try {
+      await apiFetch('/offline-exam-sync/submission', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(submission),
+      })
+    } catch {
+      remainingSubmissions.push(submission)
+    }
+  }
+
+  writeStore(SUBMISSION_QUEUE_KEY, remainingSubmissions)
+}
+
+export function getOfflineQueueSnapshot() {
+  return {
+    drafts: readStore<DraftQueueItem>(DRAFT_QUEUE_KEY),
+    submissions: readStore<SubmissionQueueItem>(SUBMISSION_QUEUE_KEY),
+  }
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -78,13 +78,13 @@ export interface Question {
   examId: string
   text: string
   imageUrl?: string
-  type: 'single' | 'multiple' | 'truefalse' | 'matching' | 'short' | 'long' | 'formula' | 'code'
+  type: 'single' | 'multiple' | 'truefalse' | 'matching' | 'short' | 'long' | 'formula' | 'chemistry' | 'code' | 'voice' | 'video' | 'handwritten'
   options?: string[]
   matchingPairs?: { left: string; right: string }[]
   correctAnswer?: string | string[]
   points: number
   order: number
-  isManualGrade: boolean   // short, long, formula, code = true
+  isManualGrade: boolean
 }
 
 export interface ExamAssignment {
@@ -158,6 +158,20 @@ export interface Result {
   submittedAt?: string
 }
 
+export type AppNotificationType = 'exam_assigned' | 'exam_started' | 'exam_submitted' | 'suspicious_event' | 'result_published'
+
+export interface AppNotification {
+  id: string
+  recipientId: string
+  title: string
+  body: string
+  type: AppNotificationType
+  examId?: string
+  classId?: string
+  isRead: boolean
+  createdAt: string
+}
+
 export type QuestionType = Question['type']
 
 export const QUESTION_TYPE_LABELS: Record<QuestionType, string> = {
@@ -168,7 +182,11 @@ export const QUESTION_TYPE_LABELS: Record<QuestionType, string> = {
   short: 'Богино текст',
   long: 'Урт текст',
   formula: 'Томъёо',
-  code: 'Код'
+  chemistry: 'Химийн томъёо',
+  code: 'CodeMirror код',
+  voice: 'Дуу бичлэг',
+  video: 'Видео хариулт',
+  handwritten: 'Гараар зурсан/медиа',
 }
 
 // Permission system


### PR DESCRIPTION
## What

Add a student exam API client and offline queue utilities in web library code.

## Why

To centralize student exam request logic and provide reusable utilities for queueing offline actions until connectivity is restored.

## Changes

- Added a student exam API client
- Added offline queue utilities
- Improved shared support for offline-capable student exam flows

## How to test

1. Open the changes under `web/lib`
2. Verify the API client and offline queue utilities are defined correctly
3. Run student exam flows and confirm requests and queued offline actions behave as expected

## Notes

This change adds shared frontend infrastructure for student exam and offline sync behavior.

Closes #833 