### PR TITLE
feat(backend): implement admin dashboard aggregation resolver

### DIFF
--- a/api/src/graphql/resolvers/admin-dashboard.resolver.ts
+++ b/api/src/graphql/resolvers/admin-dashboard.resolver.ts
@@ -15,14 +15,13 @@ export class AdminDashboardResolver {
   async getAdminDashboard(
     @Args('limit', { type: () => Int, nullable: true }) limit = 10,
   ) {
-    const [exams, dashboardStats] = await Promise.all([
+    const [exams, allSessions, dashboardStats] = await Promise.all([
       this.examService.getAllExams(),
+      this.sessionService.getAllSessions(),
       this.monitoringService.getDashboardStats(limit),
     ]);
 
-    const sessionsByExam = await Promise.all(
-      exams.map((exam) => this.sessionService.getSessionsByExam(exam.id)),
-    );
+    const totalSessions = allSessions.length;
 
     return {
       totalExams: exams.length,
@@ -30,7 +29,7 @@ export class AdminDashboardResolver {
         .length,
       totalPublishedExams: exams.filter((exam) => exam.status === 'published')
         .length,
-      totalSessions: sessionsByExam.flat().length,
+      totalSessions,
       totalSuspiciousEvents: dashboardStats.totalEvents,
       recentEvents: dashboardStats.recentEvents,
     };


### PR DESCRIPTION
## What
Implements a GraphQL resolver that aggregates system-wide metrics.

## Why
Provides a single endpoint for dashboard data, reducing multiple API calls.

## Changes
- Aggregated exams, sessions, and monitoring stats
- Used `Promise.all` for parallel execution
- Computed derived metrics (published, scheduled, total)

## How to test
- Query `adminDashboard`
- Verify returned values

## Notes
- Optimized for performance

Closes #874