### PR TITLE
feat(web): recover create exam files from local history

### DIFF
--- a/web/features/teacher/create-exam/CreateExamClient.tsx
+++ b/web/features/teacher/create-exam/CreateExamClient.tsx
@@ -1,152 +1,162 @@
-'use client'
+import type { Course, Question, Exam, QuestionType } from '@/lib/types'
+import { SUBJECT_NAMES } from '@/lib/constants'
+import { CURRENT_TEACHER_ID, save } from '@/lib/data'
+import { buildExamAssignmentNotifications, saveNotifications } from '@/lib/notifications'
+import { getApiUrl } from '@/lib/api/client'
 
-import React, { useState, useEffect, type ChangeEvent } from 'react'
-import { useRouter } from 'next/navigation'
-import { ChevronRight, Check } from 'lucide-react'
-import { getAll } from '@/lib/data'
-import type { Course, SchoolClass, Question, QuestionType } from '@/lib/types'
-import { initialCourses, initialClasses, initialQuestions } from '@/lib/data'
-import { SUBJECT_COLORS, SUBJECT_NAMES } from '@/lib/constants'
-import { toast } from '@/hooks/use-toast'
-import { ExamPreviewPanel } from './_components/ExamPreviewPanel'
-import { StepIndicator } from './_components/StepIndicator'
-import { StepSource } from './_components/StepSource'
-import { StepBasicInfo } from './_components/StepBasicInfo'
-import { StepQuestions } from './_components/StepQuestions'
-import { StepSchedule } from './_components/StepSchedule'
-import { isManualQuestionType, getCourseLabel, mapImportedQuestions, processImportFiles, generateMockAIQuestions, generateDemoQuestions, saveExamPayload, stepLabels } from './createExamUtils'
+export type ImportedQuestionPayload = {
+  question?: string; type?: 'multiple_choice' | 'true_false' | 'short_answer' | 'essay'
+  options?: string[]; correctAnswer?: string | string[]; points?: number
+}
+export type ImportApiResponse = { questions?: ImportedQuestionPayload[]; parser?: string; error?: string }
+export type ImportFailure = { fileName: string; reason: string }
 
-type Step = 1 | 2 | 3 | 4
-type QuestionTab = 'new' | 'bank' | 'ai' | 'file'
+export const stepLabels = ['Эх сурвалж', 'Ерөнхий мэдээлэл', 'Асуултууд', 'Хуваарь']
+const MANUAL_QUESTION_TYPES: QuestionType[] = ['short', 'long', 'formula', 'chemistry', 'code', 'voice', 'video', 'handwritten']
 
-export function CreateExamClient() {
-  const router = useRouter()
-  const [currentStep, setCurrentStep] = useState<Step>(1)
-  const [courses, setCourses] = useState<Course[]>(initialCourses)
-  const [classes, setClasses] = useState<SchoolClass[]>(initialClasses)
-  const [existingQuestions, setExistingQuestions] = useState<Question[]>(initialQuestions)
-  const [source, setSource] = useState<'new' | 'bank'>('new')
-  const [title, setTitle] = useState(''); const [courseId, setCourseId] = useState('')
-  const [chapter, setChapter] = useState(''); const [topic, setTopic] = useState('')
-  const [description, setDescription] = useState(''); const [duration, setDuration] = useState(45)
-  const [visibility, setVisibility] = useState<'private' | 'school'>('private')
-  const [questions, setQuestions] = useState<Question[]>([])
-  const [questionTab, setQuestionTab] = useState<QuestionTab>('new')
-  const [questionText, setQuestionText] = useState(''); const [questionType, setQuestionType] = useState<QuestionType>('single')
-  const [questionOptions, setQuestionOptions] = useState<string[]>(['', '', '', ''])
-  const [correctAnswer, setCorrectAnswer] = useState<string | string[]>('')
-  const [matchingPairs, setMatchingPairs] = useState<{ left: string; right: string }[]>([{ left: '', right: '' }, { left: '', right: '' }])
-  const [questionPoints, setQuestionPoints] = useState(2)
-  const [bankSearchQuery, setBankSearchQuery] = useState(''); const [selectedBankQuestions, setSelectedBankQuestions] = useState<string[]>([])
-  const [aiTopic, setAiTopic] = useState(''); const [aiDifficulty, setAiDifficulty] = useState<'easy' | 'medium' | 'hard'>('medium')
-  const [aiCount, setAiCount] = useState(5); const [aiGenerating, setAiGenerating] = useState(false)
-  const [aiGeneratedQuestions, setAiGeneratedQuestions] = useState<Question[]>([])
-  const [importingFile, setImportingFile] = useState(false); const [importFileName, setImportFileName] = useState('')
-  const [selectedClasses, setSelectedClasses] = useState<string[]>([])
-  const [startDate, setStartDate] = useState(''); const [startTime, setStartTime] = useState('')
-  const [endDate, setEndDate] = useState(''); const [endTime, setEndTime] = useState('')
+function getDevAuthHeaders() {
+  if (typeof window === 'undefined') {
+    return undefined
+  }
 
-  useEffect(() => {
-    const lc = getAll<Course>('courses'); const ll = getAll<SchoolClass>('classes'); const lq = getAll<Question>('questions')
-    if (lc.length) setCourses(lc); if (ll.length) setClasses(ll); if (lq.length) setExistingQuestions(lq)
+  const token = window.localStorage.getItem('seedcone.dev_auth_token')
+  return token ? { Authorization: `Bearer ${token}` } : undefined
+}
+
+function getImportApiUrl() {
+  return getApiUrl('/parse-exam')
+}
+
+async function postImportPayload(
+  payload: Record<string, unknown>,
+) {
+  const url = getImportApiUrl()
+
+  if (!url) {
+    throw new Error('NEXT_PUBLIC_API_BASE_URL is not configured.')
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...getDevAuthHeaders(),
+    },
+    body: JSON.stringify(payload),
+  })
+
+  const data = (await response.json()) as ImportApiResponse
+
+  if (!response.ok) {
+    throw new Error(data.error || 'Файл боловсруулах хүсэлт амжилтгүй боллоо.')
+  }
+
+  return data
+}
+
+export function isManualQuestionType(type: QuestionType) { return MANUAL_QUESTION_TYPES.includes(type) }
+export function getCourseLabel(course: Course) {
+  return `${SUBJECT_NAMES[course.subjectId] ?? course.subjectId} • ${course.grade}-р анги`
+}
+function arrayBufferToBase64(buffer: ArrayBuffer) {
+  let binary = ''; const bytes = new Uint8Array(buffer); const chunk = 0x8000
+  for (let i = 0; i < bytes.length; i += chunk) { binary += String.fromCharCode(...bytes.subarray(i, i + chunk)) }
+  return btoa(binary)
+}
+
+export function mapImportedQuestions(items: ImportedQuestionPayload[], existingCount: number): Question[] {
+  const baseId = Date.now()
+  return items.reduce<Question[]>((acc, item, index) => {
+    const text = item.question?.trim(); if (!text) return acc
+    const type: QuestionType = item.type === 'multiple_choice' ? 'single' : item.type === 'true_false' ? 'truefalse' : item.type === 'essay' ? 'long' : 'short'
+    const q: Question = { id: `import-q-${baseId}-${index}`, examId: '', text, type, points: Math.max(1, Number(item.points) || 10), order: existingCount + acc.length + 1, isManualGrade: isManualQuestionType(type) }
+    if (type === 'single') { q.options = Array.isArray(item.options) ? item.options.map(o => o.trim()).filter(Boolean) : []; q.correctAnswer = typeof item.correctAnswer === 'string' ? item.correctAnswer.trim() : '' }
+    else if (type === 'truefalse') { q.correctAnswer = (typeof item.correctAnswer === 'string' ? item.correctAnswer.trim().toLowerCase() : '') === 'false' ? 'false' : 'true' }
+    else if (typeof item.correctAnswer === 'string' && item.correctAnswer.trim()) { q.correctAnswer = item.correctAnswer.trim() }
+    acc.push(q); return acc
   }, [])
+}
 
-  const selectedCourse = courses.find(c => c.id === courseId)
-  const availableClasses = selectedCourse ? classes.filter(cls => selectedCourse.classIds.includes(cls.id)) : []
-  const subjectColor = SUBJECT_COLORS[(selectedCourse?.subjectId || 'math') as keyof typeof SUBJECT_COLORS] || SUBJECT_COLORS.math
-  const selectedCourseLabel = selectedCourse ? getCourseLabel(selectedCourse) : ''
-  const totalPoints = questions.reduce((sum, q) => sum + (q.points || 0), 0)
-  const filteredBankQuestions = existingQuestions.filter(q => !questions.some(e => e.id === q.id) && (bankSearchQuery === '' || q.text.toLowerCase().includes(bankSearchQuery.toLowerCase())))
+export async function processImportFiles(files: File[], title: string, courseLabel: string) {
+  const collected: ImportedQuestionPayload[] = []; const skipped: string[] = []; const failures: ImportFailure[] = []; let usedLocalParser = false
+  for (const file of files) {
+    const ext = file.name.split('.').pop()?.toLowerCase() ?? ''
+    const isBinary = ['docx', 'pdf'].includes(ext)
 
-  const handleAddQuestion = () => {
-    if (!questionText.trim()) return
-    const newQ: Question = { id: `q-new-${Date.now()}`, examId: '', text: questionText, type: questionType, points: questionPoints, order: questions.length + 1, isManualGrade: isManualQuestionType(questionType) }
-    if (questionType === 'single' || questionType === 'multiple') { newQ.options = questionOptions.filter(o => o.trim()); newQ.correctAnswer = correctAnswer }
-    else if (questionType === 'truefalse') { newQ.correctAnswer = correctAnswer }
-    else if (questionType === 'matching') { newQ.matchingPairs = matchingPairs.filter(p => p.left.trim() && p.right.trim()) }
-    setQuestions([...questions, newQ])
-    setQuestionText(''); setQuestionType('single'); setQuestionOptions(['', '', '', '']); setCorrectAnswer(''); setMatchingPairs([{ left: '', right: '' }, { left: '', right: '' }]); setQuestionPoints(2)
-  }
+    let payload: ImportApiResponse
 
-  const handleAddFromBank = () => { setQuestions([...questions, ...existingQuestions.filter(q => selectedBankQuestions.includes(q.id))]); setSelectedBankQuestions([]) }
-
-  const handleAiGenerate = async () => {
-    setAiGenerating(true); await new Promise(resolve => setTimeout(resolve, 2000))
-    setAiGeneratedQuestions(generateMockAIQuestions(aiTopic, aiDifficulty, aiCount)); setAiGenerating(false)
-  }
-
-  const handleAddAiQuestions = (ids: string[]) => {
-    setQuestions([...questions, ...aiGeneratedQuestions.filter(q => ids.includes(q.id))])
-    setAiGeneratedQuestions(aiGeneratedQuestions.filter(q => !ids.includes(q.id)))
-  }
-
-  const importFiles = async (fileList: FileList | null) => {
-    const files = fileList ? Array.from(fileList) : []; if (!files.length) return
-    setImportingFile(true); setImportFileName(files.length === 1 ? files[0].name : `${files.length} файл`)
     try {
-      const { collected, skipped, failures, usedLocalParser } = await processImportFiles(files, title, selectedCourseLabel)
-      const imported = mapImportedQuestions(collected, questions.length)
-      if (!imported.length) throw new Error('Сонгосон файл эсвэл хавтсаас асуулт олдсонгүй.')
-      setQuestions(prev => [...prev, ...imported]); setQuestionTab('new')
-      const parts = [`${imported.length} асуулт нэмэгдлээ.`, usedLocalParser && 'API key байхгүй тул локал parser ашиглалаа.', skipped.length && `${skipped.length} файл алгасагдлаа.`].filter(Boolean).join(' ')
-      toast({ title: 'Импорт амжилттай', description: parts })
-      if (failures.length > 0) {
-        const firstFailure = failures[0]
-        toast({
-          variant: 'destructive',
-          title: `${failures.length} файл алгасагдлаа`,
-          description: `${firstFailure.fileName}: ${firstFailure.reason}`,
-        })
-      }
-    } catch (err) { toast({ variant: 'destructive', title: 'Импорт амжилтгүй боллоо', description: err instanceof Error ? err.message : 'Дахин оролдоно уу.' })
-    } finally { setImportingFile(false); setImportFileName('') }
+      const fileText = isBinary ? '' : await file.text()
+      const fileBuffer = isBinary ? arrayBufferToBase64(await file.arrayBuffer()) : undefined
+      payload = await postImportPayload({
+        fileText,
+        fileBuffer,
+        fileType: file.type,
+        fileName: file.name,
+        title,
+        courseLabel,
+      })
+    } catch (error) {
+      skipped.push(file.name)
+      failures.push({
+        fileName: file.name,
+        reason: error instanceof Error ? error.message : 'Файл боловсруулах үед тодорхойгүй алдаа гарлаа.',
+      })
+      continue
+    }
+
+    if (payload.parser === 'local') usedLocalParser = true
+    if (payload.questions?.length) collected.push(...payload.questions)
+    else {
+      skipped.push(file.name)
+      failures.push({
+        fileName: file.name,
+        reason: payload.error || 'Асуулт таньж чадсангүй.',
+      })
+    }
   }
+  return { collected, skipped, failures, usedLocalParser }
+}
 
-  const handleFileUpload = async (e: ChangeEvent<HTMLInputElement>) => { await importFiles(e.target.files); e.target.value = '' }
-  const handleFolderUpload = async (e: ChangeEvent<HTMLInputElement>) => { await importFiles(e.target.files); e.target.value = '' }
+export function generateMockAIQuestions(aiTopic: string, aiDifficulty: 'easy' | 'medium' | 'hard', aiCount: number): Question[] {
+  const label = aiDifficulty === 'easy' ? 'Хөнгөн' : aiDifficulty === 'medium' ? 'Дунд' : 'Хүнд'
+  return Array.from({ length: aiCount }, (_, i) => ({
+    id: `ai-q-${Date.now()}-${i}`, examId: '',
+    text: `${aiTopic}-тэй холбоотой асуулт #${i + 1} (${label})`,
+    type: (i % 3 === 0 ? 'single' : i % 3 === 1 ? 'multiple' : 'truefalse') as QuestionType,
+    points: aiDifficulty === 'easy' ? 1 : aiDifficulty === 'medium' ? 2 : 3,
+    order: i + 1, isManualGrade: false,
+    options: i % 3 !== 2 ? ['Хариулт А', 'Хариулт Б', 'Хариулт В', 'Хариулт Г'] : undefined,
+    correctAnswer: i % 3 === 0 ? 'Хариулт А' : i % 3 === 1 ? ['Хариулт А', 'Хариулт Б'] : 'true',
+  }))
+}
 
-  const handleFillGeneralInfoDemo = () => {
-    const demoCourse = selectedCourse ?? courses[0]; if (!demoCourse) return
-    const sn = SUBJECT_NAMES[demoCourse.subjectId] ?? demoCourse.subjectId
-    setCourseId(demoCourse.id); setTitle(`${sn} - 1-р улирлын шалгалт`); setChapter(`${demoCourse.grade}-р ангийн давтлага`)
-    setTopic(sn === 'Математик' ? 'Квадрат тэгшитгэл' : `${sn} хичээлийн үндсэн сэдэв`)
-    setDescription(`${sn} хичээлийн ойлголт, бодлого бодолт, хэрэглээг шалгах demo шалгалт.`); setDuration(45); setVisibility('private')
+export function generateDemoQuestions(subjectName: string, existingCount: number): Question[] {
+  const b = Date.now()
+  return [
+    { id: `demo-q-${b}-1`, examId: '', text: `${subjectName} хичээлээс зөв тодорхойлолтыг сонгоно уу.`, type: 'single', options: ['Хариулт А', 'Хариулт Б', 'Хариулт В', 'Хариулт Г'], correctAnswer: 'Хариулт А', points: 2, order: existingCount + 1, isManualGrade: false },
+    { id: `demo-q-${b}-2`, examId: '', text: `${subjectName} хичээлийн дараах өгүүлбэр үнэн эсэхийг сонгоно уу.`, type: 'truefalse', correctAnswer: 'true', points: 1, order: existingCount + 2, isManualGrade: false },
+    { id: `demo-q-${b}-3`, examId: '', text: `${subjectName} хичээлийн гол ойлголтыг тайлбарлана уу.`, type: 'short', points: 3, order: existingCount + 3, isManualGrade: true },
+  ]
+}
+
+export function saveExamPayload(params: {
+  questions: Question[]; title: string; selectedCourse: Course; chapter: string; topic: string
+  description: string; duration: number; totalPoints: number; visibility: 'private' | 'school'
+  selectedClasses: string[]; startDate: string; startTime: string; endDate: string; endTime: string
+  classes: { id: string; name: string; studentIds: string[] }[]
+}) {
+  const { questions, title, selectedCourse, chapter, topic, description, duration, totalPoints, visibility, selectedClasses, startDate, startTime, endDate, endTime, classes } = params
+  const now = new Date().toISOString(); const newExamId = `exam-${Date.now()}`
+  const prepared = questions.map((q, i) => ({ ...q, examId: newExamId, order: i + 1, isManualGrade: isManualQuestionType(q.type) }))
+  const exam: Exam = { id: newExamId, title, subjectId: selectedCourse.subjectId, grade: selectedCourse.grade, chapter: chapter || undefined, topic: topic || undefined, description: description || undefined, duration, totalPoints, ownerType: 'teacher', visibility, ownerId: CURRENT_TEACHER_ID, collaboratorIds: [], createdAt: now, updatedAt: now, questionIds: prepared.map(q => q.id), status: selectedClasses.length > 0 ? 'published' : 'draft', isTemplate: false, tags: [selectedCourse.subjectId, chapter, topic].filter(Boolean) as string[] }
+  prepared.forEach(q => { if (/^(q-new|ai-q|demo-q|import-q)-/.test(q.id)) save('questions', q) })
+  save('exams', exam)
+  if (selectedClasses.length > 0 && startDate && startTime && endDate && endTime) {
+    selectedClasses.forEach(classId => save('examAssignments', { id: `assignment-${Date.now()}-${classId}`, examId: exam.id, classId, assignedBy: CURRENT_TEACHER_ID, scheduledStart: `${startDate}T${startTime}`, scheduledEnd: `${endDate}T${endTime}`, isPaused: false, extendedMinutes: 0, status: 'scheduled' }))
+    saveNotifications(buildExamAssignmentNotifications({
+      exam,
+      selectedClasses: classes.filter((schoolClass) => selectedClasses.includes(schoolClass.id)),
+    }))
   }
-
-  const handleAddDemoQuestions = () => {
-    const sn = selectedCourse ? (SUBJECT_NAMES[selectedCourse.subjectId] ?? selectedCourse.subjectId) : 'Ерөнхий'
-    setQuestions([...questions, ...generateDemoQuestions(sn, questions.length)])
-  }
-
-  const handleSaveExam = () => {
-    if (!selectedCourse) return
-    saveExamPayload({ questions, title, selectedCourse, chapter, topic, description, duration, totalPoints, visibility, selectedClasses, startDate, startTime, endDate, endTime, classes })
-    router.push('/teacher/exams')
-  }
-
-  const canProceed = () => { switch (currentStep) { case 1: return true; case 2: return !!(title.trim() && courseId); case 3: return questions.length > 0; case 4: return true } }
-
-  return (
-    <div className="flex h-[calc(100vh-36px)]">
-      <ExamPreviewPanel title={title} selectedCourseLabel={selectedCourseLabel} subjectColor={subjectColor} duration={duration} questions={questions} totalPoints={totalPoints} onRemoveQuestion={(index) => setQuestions(questions.filter((_, i) => i !== index))} onSave={handleSaveExam} />
-      <div className="flex-1 bg-page-bg flex flex-col">
-        <StepIndicator currentStep={currentStep} stepLabels={stepLabels} onStepClick={(step) => setCurrentStep(step as Step)} />
-        <div className="flex-1 overflow-y-auto p-8">
-          {currentStep === 1 && <StepSource source={source} onChange={setSource} />}
-          {currentStep === 2 && <StepBasicInfo title={title} courseId={courseId} chapter={chapter} topic={topic} description={description} duration={duration} visibility={visibility} courses={courses} onTitle={setTitle} onCourseId={setCourseId} onChapter={setChapter} onTopic={setTopic} onDescription={setDescription} onDuration={setDuration} onVisibility={setVisibility} onDemo={handleFillGeneralInfoDemo} />}
-          {currentStep === 3 && <StepQuestions questionTab={questionTab} questionText={questionText} questionType={questionType} questionOptions={questionOptions} correctAnswer={correctAnswer} questionPoints={questionPoints} matchingPairs={matchingPairs} bankSearchQuery={bankSearchQuery} selectedBankQuestions={selectedBankQuestions} filteredBankQuestions={filteredBankQuestions} aiTopic={aiTopic} aiDifficulty={aiDifficulty} aiCount={aiCount} aiGenerating={aiGenerating} aiGeneratedQuestions={aiGeneratedQuestions} importingFile={importingFile} importFileName={importFileName} onQuestionTab={setQuestionTab} onQuestionText={setQuestionText} onQuestionType={setQuestionType} onQuestionOptions={setQuestionOptions} onCorrectAnswer={setCorrectAnswer} onQuestionPoints={setQuestionPoints} onMatchingPairs={setMatchingPairs} onBankSearchQuery={setBankSearchQuery} onSelectedBankQuestions={setSelectedBankQuestions} onAddQuestion={handleAddQuestion} onAddFromBank={handleAddFromBank} onAiTopic={setAiTopic} onAiDifficulty={setAiDifficulty} onAiCount={setAiCount} onAiGenerate={handleAiGenerate} onAddAiQuestions={handleAddAiQuestions} onFileUpload={handleFileUpload} onFolderUpload={handleFolderUpload} onDemo={handleAddDemoQuestions} />}
-          {currentStep === 4 && <StepSchedule courseId={courseId} selectedClasses={selectedClasses} startDate={startDate} startTime={startTime} endDate={endDate} endTime={endTime} availableClasses={availableClasses} onSelectedClasses={setSelectedClasses} onStartDate={setStartDate} onStartTime={setStartTime} onEndDate={setEndDate} onEndTime={setEndTime} />}
-        </div>
-        <div className="px-8 py-4 bg-white border-t border-card-border flex items-center justify-between">
-          <button onClick={() => setCurrentStep(prev => Math.max(1, prev - 1) as Step)} disabled={currentStep === 1} className="px-4 py-2 border border-card-border rounded-lg text-[13px] font-medium text-foreground hover:bg-table-header transition-colors disabled:opacity-50">Өмнөх</button>
-          <span className="text-[13px] text-text-secondary">{questions.length} асуулт • {totalPoints} оноо</span>
-          {currentStep < 4 ? (
-            <button onClick={() => setCurrentStep(prev => Math.min(4, prev + 1) as Step)} disabled={!canProceed()} className="px-4 py-2 bg-primary text-white rounded-lg text-[13px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center gap-1.5">Дараах<ChevronRight size={14} strokeWidth={1.5} /></button>
-          ) : (
-            <button onClick={handleSaveExam} disabled={!title || questions.length === 0} className="px-4 py-2 bg-green-600 text-white rounded-lg text-[13px] font-medium hover:bg-green-700 transition-colors disabled:opacity-50 flex items-center gap-1.5"><Check size={14} strokeWidth={1.5} />Шалгалт үүсгэх</button>
-          )}
-        </div>
-      </div>
-    </div>
-  )
 }


### PR DESCRIPTION
## What

Recovers lost create-exam flow files using VSCode local history.

## Why

Some uncommitted changes were lost after a reset. This PR restores the previously implemented logic to ensure the create exam workflow functions correctly.

## Changes

* Restored `CreateExamClient.tsx` from local history
* Restored `createExamUtils.ts` and related components
* Recovered question handling logic and UI structure
* Ensured consistency with previous implementation

## How to test

* Navigate to teacher → create exam
* Go through step-by-step exam creation
* Add/edit questions (multiple types)
* Verify UI and logic behave correctly

## Notes

* No new features added
* This PR strictly restores previously implemented code
* Follow-up PRs may further refine structure if needed
